### PR TITLE
Use patched ethabi crate which supports tuple type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,20 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "7.0.0"
+source = "git+https://github.com/cryptoeconomicslab/ethabi?branch=tuple-support-v7.0.0#271aabac9c476ea6e245a03c2f02baed0e9e0393"
+dependencies = [
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethabi"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -478,6 +492,14 @@ dependencies = [
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -768,6 +790,15 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "parity-codec"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,7 +890,7 @@ name = "plasma-core"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 7.0.0 (git+https://github.com/cryptoeconomicslab/ethabi?branch=tuple-support-v7.0.0)",
  "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -914,9 +945,20 @@ dependencies = [
 name = "predicate-plugins"
 version = "0.1.0"
 dependencies = [
- "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethabi 7.0.0 (git+https://github.com/cryptoeconomicslab/ethabi?branch=tuple-support-v7.0.0)",
  "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plasma-core 0.1.0",
+ "primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1584,6 +1626,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicase"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,6 +1780,7 @@ dependencies = [
 "checksum elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "073be79b6538296faf81c631872676600616073817dd9a440c477ad09b408983"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+"checksum ethabi 7.0.0 (git+https://github.com/cryptoeconomicslab/ethabi?branch=tuple-support-v7.0.0)" = "<none>"
 "checksum ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9a03ff8f3d495d9b73d59fd166acc91d0fd81779911b0b8b4c87b6024a670a"
 "checksum ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3932e82d64d347a045208924002930dc105a138995ccdc1479d0f05f0359f17c"
 "checksum ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b054df51e53f253837ea422681215b42823c02824bde982699d0dceecf6165a1"
@@ -1751,6 +1804,7 @@ dependencies = [
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.29 (registry+https://github.com/rust-lang/crates.io-index)" = "e2cd6adf83b3347d36e271f030621a8cf95fd1fd0760546b9fc5a24a0f1447c7"
+"checksum impl-codec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2050d823639fbeae26b2b5ba09aca8907793117324858070ade0673c49f793b"
 "checksum impl-rlp 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f39b9963cf5f12fcc4ae4b30a6927ed67d6b4ea4cbe7d17a41131163b401303b"
 "checksum impl-serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d26be4b97d738552ea423f76c4f681012ff06c3fa36fa968656b3679f60b4a1"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
@@ -1784,12 +1838,14 @@ dependencies = [
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa5168b4cf41f3835e4bc6ffb32f51bc9365dc50cb351904595b3931d917fd0c"
+"checksum parity-codec 3.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dcb43c05fb71c03b4ea7327bf15694da1e0f23f19d5b1e95bab6c6d74097e336"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
+"checksum primitive-types 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2288eb2a39386c4bc817974cc413afe173010dc80e470fcb1e9a35580869f024"
 "checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1863,6 +1919,7 @@ dependencies = [
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "082df6964410f6aa929a61ddfafc997e4f32c62c22490e439ac351cec827f436"
+"checksum uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
 "checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"

--- a/client/src/state/state_manager.rs
+++ b/client/src/state/state_manager.rs
@@ -81,6 +81,7 @@ mod tests {
     use super::StateManager;
     use ethereum_types::{Address, H256};
     use plasma_core::data_structure::{StateObject, StateUpdate, Transaction, Witness};
+    use predicate_plugins::OwnershipPredicate;
 
     fn create_state_update(start: u64, end: u64, block_number: u64) -> StateUpdate {
         StateUpdate::new(
@@ -96,13 +97,15 @@ mod tests {
     fn test_execute_transaction() {
         // make state update
         let state_update = create_state_update(0, 100, 1);
+        let parameters =
+            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             0,
             100,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &b"new state update"[..],
+            &parameters,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 
@@ -117,13 +120,15 @@ mod tests {
     fn test_execute_transaction_for_partial_range() {
         // make state update
         let state_update = create_state_update(0, 100, 1);
+        let parameters =
+            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             0,
             20,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &b"new state update"[..],
+            &parameters,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 
@@ -139,13 +144,15 @@ mod tests {
         // make state update
         let state_update1 = create_state_update(0, 100, 1);
         let state_update2 = create_state_update(100, 200, 2);
+        let parameters =
+            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             50,
             150,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &b"new state update"[..],
+            &parameters,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 

--- a/client/src/state/state_manager.rs
+++ b/client/src/state/state_manager.rs
@@ -54,7 +54,7 @@ impl StateManager {
         let new_state_updates: Vec<StateUpdate> = verified_state_updates
             .iter()
             .map(|verified_state_update| {
-                let predicate_address: &Address = verified_state_update
+                let predicate_address: Address = verified_state_update
                     .get_state_update()
                     .get_state_object()
                     .get_predicate();
@@ -81,7 +81,7 @@ mod tests {
     use super::StateManager;
     use ethereum_types::{Address, H256};
     use plasma_core::data_structure::{StateObject, StateUpdate, Transaction, Witness};
-    use predicate_plugins::OwnershipPredicate;
+    use predicate_plugins::{OwnershipPredicateParameters, PredicateParameters};
 
     fn create_state_update(start: u64, end: u64, block_number: u64) -> StateUpdate {
         StateUpdate::new(
@@ -97,15 +97,19 @@ mod tests {
     fn test_execute_transaction() {
         // make state update
         let state_update = create_state_update(0, 100, 1);
-        let parameters =
-            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
+        let parameters = OwnershipPredicateParameters::new(
+            StateObject::new(Address::zero(), &Address::zero().as_bytes().to_vec()),
+            5,
+            10,
+        );
+        let parameters_bytes = parameters.encode();
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             0,
             100,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &parameters,
+            &parameters_bytes,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 
@@ -120,15 +124,19 @@ mod tests {
     fn test_execute_transaction_for_partial_range() {
         // make state update
         let state_update = create_state_update(0, 100, 1);
-        let parameters =
-            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
+        let parameters = OwnershipPredicateParameters::new(
+            StateObject::new(Address::zero(), &Address::zero().as_bytes().to_vec()),
+            5,
+            10,
+        );
+        let parameters_bytes = parameters.encode();
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             0,
             20,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &parameters,
+            &parameters_bytes,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 
@@ -144,15 +152,19 @@ mod tests {
         // make state update
         let state_update1 = create_state_update(0, 100, 1);
         let state_update2 = create_state_update(100, 200, 2);
-        let parameters =
-            OwnershipPredicate::make_parameters(Address::zero(), Address::zero(), 5, 10);
+        let parameters = OwnershipPredicateParameters::new(
+            StateObject::new(Address::zero(), &Address::zero().as_bytes().to_vec()),
+            5,
+            10,
+        );
+        let parameters_bytes = parameters.encode();
         // make transaction
         let transaction = Transaction::new(
             Address::zero(),
             50,
             150,
             Transaction::create_method_id(&b"send(address)"[..]),
-            &parameters,
+            &parameters_bytes,
             &Witness::new(H256::zero(), H256::zero(), 0),
         );
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
-ethabi = "7.0.0"
+ethabi = { git = 'https://github.com/cryptoeconomicslab/ethabi', branch = 'tuple-support-v7.0.0' }
 ethereum-types = "^0.5.2"
 failure = "0.1.5"
 rlp = "0.4.0"

--- a/core/src/data_structure/state_object.rs
+++ b/core/src/data_structure/state_object.rs
@@ -50,8 +50,11 @@ impl StateObject {
         .map_err(|_e| Error::from(ErrorKind::AbiDecode))?;
         Self::from_tuple(&decoded)
     }
-    pub fn get_predicate(&self) -> &Address {
-        &self.predicate
+    pub fn get_predicate(&self) -> Address {
+        self.predicate
+    }
+    pub fn get_data(&self) -> &[u8] {
+        &self.data
     }
 }
 

--- a/core/src/data_structure/state_object.rs
+++ b/core/src/data_structure/state_object.rs
@@ -33,19 +33,22 @@ impl StateObject {
             Token::Bytes(self.data.clone()),
         ])
     }
+    pub fn from_tuple(tuple: &[Token]) -> Result<Self, Error> {
+        let predicate = tuple[0].clone().to_address();
+        let data = tuple[1].clone().to_bytes();
+        if let (Some(predicate), Some(data)) = (predicate, data) {
+            Ok(StateObject::new(predicate, &data))
+        } else {
+            Err(Error::from(ErrorKind::AbiDecode))
+        }
+    }
     pub fn from_abi(data: &[u8]) -> Result<Self, Error> {
         let decoded: Vec<Token> = ethabi::decode(
             &[ethabi::ParamType::Address, ethabi::ParamType::Bytes],
             data,
         )
         .map_err(|_e| Error::from(ErrorKind::AbiDecode))?;
-        let predicate = decoded[0].clone().to_address();
-        let data = decoded[1].clone().to_bytes();
-        if let (Some(predicate), Some(data)) = (predicate, data) {
-            Ok(StateObject::new(predicate, &data))
-        } else {
-            Err(Error::from(ErrorKind::AbiDecode))
-        }
+        Self::from_tuple(&decoded)
     }
     pub fn get_predicate(&self) -> &Address {
         &self.predicate

--- a/core/src/data_structure/transaction.rs
+++ b/core/src/data_structure/transaction.rs
@@ -140,6 +140,9 @@ impl Transaction {
     pub fn get_parameters(&self) -> &[u8] {
         &self.parameters
     }
+    pub fn get_plasma_contract_address(&self) -> Address {
+        self.plasma_contract_address
+    }
 }
 
 impl Encodable for Transaction {

--- a/predicate-plugins/Cargo.toml
+++ b/predicate-plugins/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Cryptoeconomics Lab <info@cryptoeconomicslab.com>"]
 edition = "2018"
 
 [dependencies]
-ethabi = "7.0.0"
+ethabi = { git = 'https://github.com/cryptoeconomicslab/ethabi', branch = 'tuple-support-v7.0.0' }
 ethereum-types = "^0.5.2"
+primitive-types = "0.3.0"
 plasma-core = { path = "../core" }

--- a/predicate-plugins/src/lib.rs
+++ b/predicate-plugins/src/lib.rs
@@ -2,5 +2,6 @@ pub mod ownership;
 pub mod predicate;
 pub mod predicate_manager;
 
+pub use ownership::OwnershipPredicate;
 pub use predicate::PredicatePlugin;
 pub use predicate_manager::PredicateManager;

--- a/predicate-plugins/src/lib.rs
+++ b/predicate-plugins/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod ownership;
+pub mod parameters;
 pub mod predicate;
 pub mod predicate_manager;
 
-pub use ownership::OwnershipPredicate;
+pub use ownership::{OwnershipPredicate, OwnershipPredicateParameters};
+pub use parameters::PredicateParameters;
 pub use predicate::PredicatePlugin;
 pub use predicate_manager::PredicateManager;

--- a/predicate-plugins/src/ownership.rs
+++ b/predicate-plugins/src/ownership.rs
@@ -1,8 +1,55 @@
 use crate::predicate::PredicatePlugin;
-use plasma_core::data_structure::{StateUpdate, Transaction};
+use ethabi::{ParamType, Token};
+use ethereum_types::Address;
+use plasma_core::data_structure::{StateObject, StateUpdate, Transaction};
 
 /// Simple ownership predicate
 pub struct OwnershipPredicate {}
+
+impl OwnershipPredicate {
+    /// Make parameters for ownership predicate
+    pub fn make_parameters(
+        predicate: Address,
+        owner: Address,
+        origin_block: u64,
+        max_block: u64,
+    ) -> Vec<u8> {
+        ethabi::encode(&[
+            Token::Tuple(vec![
+                Token::Address(predicate),
+                Token::Bytes(owner.as_bytes().to_vec()),
+            ]),
+            Token::Uint(origin_block.into()),
+            Token::Uint(max_block.into()),
+        ])
+    }
+    /// Parse parameters of ownership predicate
+    pub fn parse_parameters(data: &[u8]) -> Option<(StateObject, u64, u64)> {
+        ethabi::decode(
+            &[
+                ParamType::Tuple(vec![ParamType::Address, ParamType::Bytes]),
+                ParamType::Uint(16),
+                ParamType::Uint(16),
+            ],
+            data,
+        )
+        .ok()
+        .and_then(|decoded| {
+            let state_object_tuple = decoded[0].clone().to_tuple();
+            let origin_block = decoded[1].clone().to_uint();
+            let max_block = decoded[2].clone().to_uint();
+            if let (Some(state_object_tuple), Some(origin_block), Some(max_block)) =
+                (state_object_tuple, origin_block, max_block)
+            {
+                StateObject::from_tuple(&state_object_tuple)
+                    .ok()
+                    .map(|state_object| (state_object, origin_block.as_u64(), max_block.as_u64()))
+            } else {
+                None
+            }
+        })
+    }
+}
 
 impl Default for OwnershipPredicate {
     fn default() -> Self {
@@ -14,10 +61,22 @@ impl PredicatePlugin for OwnershipPredicate {
     fn execute_state_transition(
         &self,
         input: &StateUpdate,
-        _transaction: &Transaction,
+        transaction: &Transaction,
     ) -> StateUpdate {
         // should parse transaction.parameters
         // make new state update
-        input.clone()
+        let (state_object, origin_block, max_block) =
+            Self::parse_parameters(transaction.get_parameters()).unwrap();
+        // Where does the function get pending block number from?
+        let pending_block_number = max_block;
+        assert!(input.get_block_number() <= origin_block);
+        assert!(pending_block_number <= max_block);
+        StateUpdate::new(
+            &state_object,
+            transaction.get_start(),
+            transaction.get_end(),
+            pending_block_number,
+            transaction.get_plasma_contract_address(),
+        )
     }
 }

--- a/predicate-plugins/src/parameters.rs
+++ b/predicate-plugins/src/parameters.rs
@@ -1,0 +1,5 @@
+/// Parameters of predicate, parameters must be ABI encoded
+pub trait PredicateParameters {
+    /// Encodes to ABI
+    fn encode(&self) -> Vec<u8>;
+}

--- a/predicate-plugins/src/predicate_manager.rs
+++ b/predicate-plugins/src/predicate_manager.rs
@@ -6,7 +6,7 @@ use ethereum_types::Address;
 pub struct PredicateManager {}
 
 impl PredicateManager {
-    pub fn get_plugin(_address: &Address) -> Box<dyn PredicatePlugin> {
+    pub fn get_plugin(_address: Address) -> Box<dyn PredicatePlugin> {
         let predicate: OwnershipPredicate = Default::default();
         Box::new(predicate)
     }


### PR DESCRIPTION
## Description

Add abi decoder and encoder for transaction parameters of ownership predicate, and implement execute_state_transition method.

### Tasks

- Add utility methods for creating parameters of OwnershipPredicate
- Implement execute_state_transition of OwnershipPredicate
- Make patched version of `ethabi` which supports tuple type. see also https://github.com/paritytech/ethabi/pull/102.

Close #53 
