### PR TITLE
Add query_state method in StateManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
 name = "plasma-client"
 version = "0.1.0"
 dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 7.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -953,6 +954,7 @@ dependencies = [
 name = "predicate-plugins"
 version = "0.1.0"
 dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 7.0.0 (git+https://github.com/cryptoeconomicslab/ethabi?branch=tuple-support-v7.0.0)",
  "ethereum-types 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plasma-core 0.1.0",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Cryptoeconomics Lab <info@cryptoeconomicslab.com>"]
 edition = "2018"
 
 [dependencies]
+bytes = "0.4.12"
 ethabi = "7.0.0"
 ethereum-types = "^0.5.2"
 failure = "0.1.5"

--- a/predicate-plugins/Cargo.toml
+++ b/predicate-plugins/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Cryptoeconomics Lab <info@cryptoeconomicslab.com>"]
 edition = "2018"
 
 [dependencies]
+bytes = "0.4.12"
 ethabi = { git = 'https://github.com/cryptoeconomicslab/ethabi', branch = 'tuple-support-v7.0.0' }
 ethereum-types = "^0.5.2"
 primitive-types = "0.3.0"

--- a/predicate-plugins/src/predicate.rs
+++ b/predicate-plugins/src/predicate.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use plasma_core::data_structure::{StateUpdate, Transaction};
 
 /// Base class of predicate plugin
@@ -7,4 +8,6 @@ pub trait PredicatePlugin {
         input: &StateUpdate,
         transaction: &Transaction,
     ) -> StateUpdate;
+
+    fn query_state(&self, state_update: &StateUpdate, parameters: &[u8]) -> Vec<Bytes>;
 }


### PR DESCRIPTION
This is the remained task of #44 

- [x] Add query_state method to StateManager
- [x] Add query_state method to PredicatePlugin
- [x] Add spec for query_state

**another topic**

Which type we should use for "bytes" in result type?
bytes::Bytes, Vec<u8>, Box<[u8]>, original type
