### PR TITLE
event-watcher: Update README

### DIFF
--- a/event-watcher/README.md
+++ b/event-watcher/README.md
@@ -21,7 +21,8 @@ fn main() {
             anonymous: false,
         }
     ];
-    let db = DefaultEventDb::new();
+    let kvs = CoreDbMemoryImpl::open("kvs");
+    let db = EventDbImpl::from(kvs);
     let mut watcher = EventWatcher::new("http://localhost:9545", address, abi, db);
 
     watcher.subscribe(Box::new(|log| {


### PR DESCRIPTION
Updated to follow https://github.com/cryptoeconomicslab/plasma-rust-framework/pull/102. Or It might be better to link to the [main.rs](https://github.com/cryptoeconomicslab/plasma-rust-framework/blob/master/event-watcher/src/main.rs) for the time being instead of updating the sample code each time.

