### PR TITLE
Remove generics of output type from KeyValueStore #105

### DIFF
--- a/client/src/state/state_db.rs
+++ b/client/src/state/state_db.rs
@@ -5,7 +5,6 @@ use ethabi::Token;
 use plasma_core::data_structure::abi::{Decodable, Encodable};
 use plasma_core::data_structure::StateUpdate;
 use plasma_db::impls::rangedb::RangeDbImpl;
-use plasma_db::range::Range;
 use plasma_db::traits::{DatabaseTrait, KeyValueStore, RangeStore};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -86,13 +85,13 @@ impl VerifiedStateUpdate {
     }
 }
 
-pub struct StateDb<KVS: KeyValueStore<Range>> {
+pub struct StateDb<KVS: KeyValueStore> {
     db: Box<RangeDbImpl<KVS>>,
 }
 
 impl<KVS> Default for StateDb<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<Range>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     fn default() -> Self {
         let base_db = KVS::open("state");
@@ -104,7 +103,7 @@ where
 
 impl<KVS> StateDb<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<Range>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     pub fn get_verified_state_updates(
         &self,

--- a/client/src/state/state_manager.rs
+++ b/client/src/state/state_manager.rs
@@ -2,7 +2,6 @@ use crate::error::{Error, ErrorKind};
 use crate::state::{StateDb, VerifiedStateUpdate};
 use ethereum_types::Address;
 use plasma_core::data_structure::{StateQuery, StateQueryResult, StateUpdate, Transaction};
-use plasma_db::range::Range;
 use plasma_db::traits::{DatabaseTrait, KeyValueStore};
 use predicate_plugins::PredicateManager;
 
@@ -26,13 +25,13 @@ impl ResultOfExecuteTransaction {
     }
 }
 
-pub struct StateManager<KVS: KeyValueStore<Range>> {
+pub struct StateManager<KVS: KeyValueStore> {
     db: Box<StateDb<KVS>>,
 }
 
 impl<KVS> Default for StateManager<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<Range>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     fn default() -> Self {
         Self {
@@ -43,7 +42,7 @@ where
 
 impl<KVS> StateManager<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<Range>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     /// force to put state update
     pub fn deposit(&self, start: u64, end: u64, state_update: StateUpdate) -> Result<(), Error> {

--- a/client/src/sync/sync_db.rs
+++ b/client/src/sync/sync_db.rs
@@ -8,13 +8,13 @@ use plasma_db::traits::{BaseDbKey, KeyValueStore};
 
 /// SyncDb is used by SyncManager to store
 /// see http://spec.plasma.group/en/latest/src/05-client-architecture/sync-db.html
-pub struct SyncDb<KVS: KeyValueStore<StateQuery>> {
+pub struct SyncDb<KVS: KeyValueStore> {
     db: KVS,
 }
 
 impl<KVS> SyncDb<KVS>
 where
-    KVS: KeyValueStore<StateQuery>,
+    KVS: KeyValueStore,
 {
     pub fn new(db: KVS) -> Self {
         Self { db }
@@ -23,7 +23,7 @@ where
 
 impl<KVS> SyncDb<KVS>
 where
-    KVS: KeyValueStore<StateQuery>,
+    KVS: KeyValueStore,
 {
     pub fn get_commitment_contracts(&self) -> Vec<Address> {
         vec![]

--- a/client/src/sync/sync_manager.rs
+++ b/client/src/sync/sync_manager.rs
@@ -7,14 +7,14 @@ use plasma_core::types::BlockNumber;
 use plasma_db::traits::{DatabaseTrait, KeyValueStore};
 
 /// SyncManager synchronize client state with operator's state.
-pub struct SyncManager<KVS: KeyValueStore<StateQuery>> {
+pub struct SyncManager<KVS: KeyValueStore> {
     sync_db: SyncDb<KVS>,
     uri: String,
 }
 
 impl<KVS> SyncManager<KVS>
 where
-    KVS: KeyValueStore<StateQuery>,
+    KVS: KeyValueStore,
 {
     pub fn new(sync_db: SyncDb<KVS>, uri: String) -> Self {
         Self { sync_db, uri }
@@ -23,7 +23,7 @@ where
 
 impl<KVS> Default for SyncManager<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<StateQuery>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     fn default() -> Self {
         Self {
@@ -35,7 +35,7 @@ where
 
 impl<KVS> SyncManager<KVS>
 where
-    KVS: DatabaseTrait + KeyValueStore<StateQuery>,
+    KVS: DatabaseTrait + KeyValueStore,
 {
     /// Callback which is called when new block is submitted
     pub fn sync(&self) -> Vec<StateQueryResult> {

--- a/event-watcher/src/event_db.rs
+++ b/event-watcher/src/event_db.rs
@@ -14,7 +14,7 @@ pub struct EventDbImpl<KVS> {
 
 impl<KVS> From<KVS> for EventDbImpl<KVS>
 where
-    KVS: KeyValueStore<Vec<u8>>,
+    KVS: KeyValueStore,
 {
     fn from(db: KVS) -> Self {
         Self { db }
@@ -23,7 +23,7 @@ where
 
 impl<KVS> EventDb for EventDbImpl<KVS>
 where
-    KVS: KeyValueStore<Vec<u8>>,
+    KVS: KeyValueStore,
 {
     fn get_last_logged_block(&self, topic_hash: Hash) -> Option<u64> {
         match self.db.get(&BaseDbKey::new(topic_hash.0.to_vec())) {

--- a/operator/src/block/block_db.rs
+++ b/operator/src/block/block_db.rs
@@ -4,7 +4,6 @@ use plasma_core::data_structure::abi::{Decodable, Encodable};
 use plasma_core::data_structure::StateUpdate;
 use plasma_core::types::BlockNumber;
 use plasma_db::impls::rangedb::RangeDbImpl;
-use plasma_db::range::Range;
 use plasma_db::traits::{BaseDbKey, Bucket, DatabaseTrait, KeyValueStore, RangeStore};
 
 static NEXT_BLOCK_KEY: &[u8; 10] = b"next_block";
@@ -17,7 +16,7 @@ pub struct BlockDb<D> {
 
 impl<D> Default for BlockDb<D>
 where
-    D: DatabaseTrait + KeyValueStore<Range>,
+    D: DatabaseTrait + KeyValueStore,
 {
     fn default() -> Self {
         Self {
@@ -29,7 +28,7 @@ where
 
 impl<D> BlockDb<D>
 where
-    D: DatabaseTrait + KeyValueStore<Range>,
+    D: DatabaseTrait + KeyValueStore,
 {
     pub fn set_block_number(&self, block_number: BlockNumber) -> Result<(), Error> {
         let value: Bytes = block_number.into();
@@ -72,11 +71,11 @@ where
             next_block.unwrap().as_slice(),
         )))
     }
-    pub fn get_next_block_store(&self) -> Result<RangeDbImpl<Bucket<Range>>, Error> {
+    pub fn get_next_block_store(&self) -> Result<RangeDbImpl<Bucket>, Error> {
         let next_block_number = self.get_next_block_number()?;
         Ok(self.get_block_store(next_block_number))
     }
-    pub fn get_block_store(&self, block_number: BlockNumber) -> RangeDbImpl<Bucket<Range>> {
+    pub fn get_block_store(&self, block_number: BlockNumber) -> RangeDbImpl<Bucket> {
         let key: BaseDbKey = block_number.as_u64().into();
         let bucket = self.db.bucket(&key);
         RangeDbImpl::from(bucket)

--- a/operator/src/block/block_manager.rs
+++ b/operator/src/block/block_manager.rs
@@ -2,7 +2,6 @@ use super::block_db::BlockDb;
 use crate::error::Error;
 use plasma_core::data_structure::StateUpdate;
 use plasma_core::types::BlockNumber;
-use plasma_db::range::Range;
 use plasma_db::traits::db::DatabaseTrait;
 use plasma_db::traits::kvs::KeyValueStore;
 
@@ -13,7 +12,7 @@ pub struct BlockManager<D> {
 
 impl<D> Default for BlockManager<D>
 where
-    D: DatabaseTrait + KeyValueStore<Range>,
+    D: DatabaseTrait + KeyValueStore,
 {
     fn default() -> Self {
         Self {
@@ -24,7 +23,7 @@ where
 
 impl<D> BlockManager<D>
 where
-    D: DatabaseTrait + KeyValueStore<Range>,
+    D: DatabaseTrait + KeyValueStore,
 {
     pub fn initiate(&self) -> Result<(), Error> {
         self.db.set_block_number(BlockNumber::new(0))


### PR DESCRIPTION
## Description

Clean KeyValueStore. Remove generics of `iter_all_map`.

### Purpose

To make SyncManager simple. https://github.com/cryptoeconomicslab/plasma-rust-framework/pull/103/files#diff-33ff022e000b0a0e743dfbd7fcd48c87R19

Close #105 