### PR TITLE
Add state channel exit property spec

### DIFF
--- a/db/src/traits/kvs.rs
+++ b/db/src/traits/kvs.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use std::cmp::Ordering;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -27,6 +27,12 @@ impl BaseDbKey {
 impl From<&[u8]> for BaseDbKey {
     fn from(array: &[u8]) -> Self {
         BaseDbKey::new(array.to_vec())
+    }
+}
+
+impl From<Bytes> for BaseDbKey {
+    fn from(bytes: Bytes) -> Self {
+        BaseDbKey::new(bytes.to_vec())
     }
 }
 

--- a/ovm/src/db.rs
+++ b/ovm/src/db.rs
@@ -1,3 +1,3 @@
 pub mod message_db;
 
-pub use self::message_db::MessageDb;
+pub use self::message_db::{Message, MessageDb};

--- a/ovm/src/db.rs
+++ b/ovm/src/db.rs
@@ -1,0 +1,3 @@
+pub mod message_db;
+
+pub use self::message_db::MessageDb;

--- a/ovm/src/db/message_db.rs
+++ b/ovm/src/db/message_db.rs
@@ -8,11 +8,12 @@ use plasma_core::data_structure::error::{
 };
 use plasma_db::traits::kvs::KeyValueStore;
 
+#[derive(Clone, Debug)]
 pub struct Message {
-    channel_id: Bytes,
+    pub channel_id: Bytes,
     sender: Address,
     recipient: Address,
-    nonce: Integer,
+    pub nonce: Integer,
     signers: Vec<Address>,
     message: Bytes,
     signed_message: Bytes,

--- a/ovm/src/db/message_db.rs
+++ b/ovm/src/db/message_db.rs
@@ -1,0 +1,148 @@
+use crate::types::Integer;
+use bytes::Bytes;
+use ethabi::{ParamType, Token};
+use ethereum_types::Address;
+use plasma_core::data_structure::abi::{Decodable, Encodable};
+use plasma_core::data_structure::error::{
+    Error as PlasmaCoreError, ErrorKind as PlasmaCoreErrorKind,
+};
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct Message {
+    channel_id: Bytes,
+    sender: Address,
+    recipient: Address,
+    nonce: Integer,
+    signers: Vec<Address>,
+    message: Bytes,
+    signed_message: Bytes,
+}
+
+impl Message {
+    pub fn get_signers(&self) -> &Vec<Address> {
+        &self.signers
+    }
+}
+
+impl Encodable for Message {
+    fn to_abi(&self) -> Vec<u8> {
+        ethabi::encode(&self.to_tuple())
+    }
+    fn to_tuple(&self) -> Vec<Token> {
+        vec![
+            Token::Bytes(self.channel_id.to_vec()),
+            Token::Address(self.sender),
+            Token::Address(self.recipient),
+            Token::Uint(self.nonce.0.into()),
+            Token::Array(self.signers.iter().map(|s| Token::Address(*s)).collect()),
+            Token::Bytes(self.message.to_vec()),
+            Token::Bytes(self.signed_message.to_vec()),
+        ]
+    }
+}
+
+impl Decodable for Message {
+    type Ok = Message;
+    fn from_tuple(tuple: &[Token]) -> Result<Self, PlasmaCoreError> {
+        let channel_id = tuple[0].clone().to_bytes();
+        let sender = tuple[1].clone().to_address();
+        let recipient = tuple[2].clone().to_address();
+        let nonce = tuple[3].clone().to_uint();
+        let signers = tuple[4].clone().to_array();
+        let message = tuple[5].clone().to_bytes();
+        let signed_message = tuple[6].clone().to_bytes();
+        if let (
+            Some(channel_id),
+            Some(sender),
+            Some(recipient),
+            Some(nonce),
+            Some(signers),
+            Some(message),
+            Some(signed_message),
+        ) = (
+            channel_id,
+            sender,
+            recipient,
+            nonce,
+            signers,
+            message,
+            signed_message,
+        ) {
+            Ok(Message {
+                channel_id: Bytes::from(channel_id),
+                sender,
+                recipient,
+                nonce: Integer(nonce.as_u64()),
+                signers: signers
+                    .iter()
+                    .map(|s| s.clone().to_address().unwrap())
+                    .collect(),
+                message: Bytes::from(message),
+                signed_message: Bytes::from(signed_message),
+            })
+        } else {
+            Err(PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))
+        }
+    }
+    fn from_abi(data: &[u8]) -> Result<Self, PlasmaCoreError> {
+        let decoded = ethabi::decode(
+            &[
+                ParamType::Bytes,
+                ParamType::Address,
+                ParamType::Address,
+                ParamType::Uint(256),
+                ParamType::Array(Box::new(ParamType::Address)),
+                ParamType::Bytes,
+                ParamType::Bytes,
+            ],
+            data,
+        )
+        .map_err(|_e| PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))?;
+        Self::from_tuple(&decoded)
+    }
+}
+
+pub struct MessageDb<KVS> {
+    db: KVS,
+}
+
+impl<KVS> MessageDb<KVS>
+where
+    KVS: KeyValueStore,
+{
+    pub fn get_message_by_channel_id_and_nonce(
+        &self,
+        channel_id: Bytes,
+        nonce: Integer,
+    ) -> Option<Message> {
+        let nonce_bytes: Bytes = nonce.into();
+        self.db
+            .bucket(&channel_id.into())
+            .get(&nonce_bytes.into())
+            .ok()
+            .unwrap()
+            .map(|b| Message::from_abi(&b).ok().unwrap())
+    }
+    pub fn get_messages_signed_by(
+        &self,
+        signer: Address,
+        _channel_id: Option<Bytes>,
+        _nonce: Option<Integer>,
+    ) -> Vec<Message> {
+        self.db
+            .iter_all(&Bytes::from("").into(), Box::new(move |_k, _v| true))
+            .iter()
+            .filter_map(|kv| Message::from_abi(kv.get_value()).ok())
+            .filter(|message| message.get_signers().contains(&signer))
+            .collect()
+    }
+}
+
+impl<KVS> From<KVS> for MessageDb<KVS>
+where
+    KVS: KeyValueStore,
+{
+    fn from(kvs: KVS) -> Self {
+        Self { db: kvs }
+    }
+}

--- a/ovm/src/deciders.rs
+++ b/ovm/src/deciders.rs
@@ -1,11 +1,13 @@
 pub mod and_decider;
 pub mod for_all_such_that_decider;
+pub mod has_lower_nonce;
 pub mod not_decider;
 pub mod preimage_exists_decider;
 pub mod signed_by_decider;
 
 pub use self::and_decider::AndDecider;
 pub use self::for_all_such_that_decider::ForAllSuchThatDecider;
+pub use self::has_lower_nonce::HasLowerNonceDecider;
 pub use self::not_decider::NotDecider;
 pub use self::preimage_exists_decider::PreimageExistsDecider;
-pub use self::signed_by_decider::SignedByDecider;
+pub use self::signed_by_decider::{SignedByDecider, Verifier as SignVerifier};

--- a/ovm/src/deciders/for_all_such_that_decider.rs
+++ b/ovm/src/deciders/for_all_such_that_decider.rs
@@ -5,6 +5,7 @@ use crate::types::{
 };
 use crate::DecideMixin;
 use bytes::Bytes;
+use plasma_db::traits::kvs::KeyValueStore;
 
 /// ForAllSuchThatDecider decides for all quantified results by PropertyFactory and WitnessFactory
 pub struct ForAllSuchThatDecider {}
@@ -43,8 +44,8 @@ impl Default for ForAllSuchThatDecider {
 
 impl Decider for ForAllSuchThatDecider {
     type Input = ForAllSuchThatInput;
-    fn decide(
-        decider: &PropertyExecutor,
+    fn decide<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &ForAllSuchThatInput,
         _witness: Option<&Bytes>,
     ) -> Result<Decision, Error> {
@@ -81,8 +82,8 @@ impl Decider for ForAllSuchThatDecider {
             any_undecided || !quantifier_result.get_all_results_quantified(),
         )
     }
-    fn check_decision(
-        decider: &PropertyExecutor,
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &ForAllSuchThatInput,
     ) -> Result<Decision, Error> {
         Self::decide(decider, input, None)
@@ -98,6 +99,7 @@ mod tests {
         Decider, Decision, ForAllSuchThatInput, Integer, PreimageExistsInput, Property,
         PropertyFactory, Quantifier, WitnessFactory,
     };
+    use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
@@ -110,7 +112,7 @@ mod tests {
             })),
             WitnessFactory::new(Box::new(|bytes| bytes.clone())),
         );
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided: Decision = ForAllSuchThatDecider::decide(&decider, &input, None).unwrap();
         assert_eq!(decided.get_outcome(), true);
     }

--- a/ovm/src/deciders/has_lower_nonce.rs
+++ b/ovm/src/deciders/has_lower_nonce.rs
@@ -1,0 +1,47 @@
+use crate::error::Error;
+use crate::property_executor::PropertyExecutor;
+use crate::types::{Decider, Decision, HasLowerNonceInput, ImplicationProofElement, Property};
+use bytes::Bytes;
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct HasLowerNonceDecider {}
+
+impl HasLowerNonceDecider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for HasLowerNonceDecider {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl Decider for HasLowerNonceDecider {
+    type Input = HasLowerNonceInput;
+    fn decide<T: KeyValueStore>(
+        _decider: &PropertyExecutor<T>,
+        input: &HasLowerNonceInput,
+        _witness: Option<&Bytes>,
+    ) -> Result<Decision, Error> {
+        if input.get_message().nonce < input.get_nonce() {
+            Ok(Decision::new(
+                true,
+                vec![ImplicationProofElement::new(
+                    Property::HasLowerNonceDecider(input.clone()),
+                    None,
+                )],
+            ))
+        } else {
+            Ok(Decision::new(false, vec![]))
+        }
+    }
+
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
+        input: &HasLowerNonceInput,
+    ) -> Result<Decision, Error> {
+        Self::decide(decider, input, None)
+    }
+}

--- a/ovm/src/deciders/not_decider.rs
+++ b/ovm/src/deciders/not_decider.rs
@@ -3,6 +3,7 @@ use crate::property_executor::PropertyExecutor;
 use crate::types::{Decider, Decision, ImplicationProofElement, NotDeciderInput, Property};
 use crate::DecideMixin;
 use bytes::Bytes;
+use plasma_db::traits::kvs::KeyValueStore;
 
 pub struct NotDecider {}
 
@@ -20,8 +21,8 @@ impl Default for NotDecider {
 
 impl Decider for NotDecider {
     type Input = NotDeciderInput;
-    fn decide(
-        decider: &PropertyExecutor,
+    fn decide<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &NotDeciderInput,
         _witness: Option<&Bytes>,
     ) -> Result<Decision, Error> {
@@ -42,8 +43,8 @@ impl Decider for NotDecider {
         ))
     }
 
-    fn check_decision(
-        decider: &PropertyExecutor,
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &NotDeciderInput,
     ) -> Result<Decision, Error> {
         Self::decide(decider, input, None)

--- a/ovm/src/deciders/preimage_exists_decider.rs
+++ b/ovm/src/deciders/preimage_exists_decider.rs
@@ -122,8 +122,8 @@ impl Default for PreimageExistsDecider {
 
 impl Decider for PreimageExistsDecider {
     type Input = PreimageExistsInput;
-    fn decide(
-        decider: &PropertyExecutor,
+    fn decide<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &PreimageExistsInput,
         witness_bytes: Option<&Bytes>,
     ) -> Result<Decision, Error> {
@@ -146,8 +146,8 @@ impl Decider for PreimageExistsDecider {
 
         Ok(Decision::new(true, vec![]))
     }
-    fn check_decision(
-        decider: &PropertyExecutor,
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &PreimageExistsInput,
     ) -> Result<Decision, Error> {
         let decision_key = input.get_hash();
@@ -179,13 +179,14 @@ mod tests {
     use crate::property_executor::PropertyExecutor;
     use crate::types::{Decider, Decision, PreimageExistsInput, Property};
     use bytes::Bytes;
+    use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
         let input = PreimageExistsInput::new(Verifier::static_hash(&Bytes::from("left")));
         let property = Property::PreimageExistsDecider(Box::new(input.clone()));
         let witness = Bytes::from("left");
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided: Decision = decider.decide(&property, Some(&witness)).unwrap();
         assert_eq!(decided.get_outcome(), true);
         let status = PreimageExistsDecider::check_decision(&decider, &input).unwrap();

--- a/ovm/src/deciders/signed_by_decider.rs
+++ b/ovm/src/deciders/signed_by_decider.rs
@@ -111,8 +111,8 @@ impl Default for SignedByDecider {
 
 impl Decider for SignedByDecider {
     type Input = SignedByInput;
-    fn decide(
-        decider: &PropertyExecutor,
+    fn decide<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &SignedByInput,
         witness_bytes: Option<&Bytes>,
     ) -> Result<Decision, Error> {
@@ -135,8 +135,8 @@ impl Decider for SignedByDecider {
 
         Ok(Decision::new(true, vec![]))
     }
-    fn check_decision(
-        decider: &PropertyExecutor,
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &SignedByInput,
     ) -> Result<Decision, Error> {
         let decision_key = input.hash();
@@ -167,6 +167,7 @@ mod tests {
     use crate::types::{Decider, Decision, Property, SignedByInput};
     use bytes::Bytes;
     use ethsign::SecretKey;
+    use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
@@ -178,7 +179,7 @@ mod tests {
         let signature = Verifier::sign(&secret_key, &message);
         let input = SignedByInput::new(message, secret_key.public().address().into());
         let property = Property::SignedByDecider(input.clone());
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided: Decision = decider.decide(&property, Some(&signature)).unwrap();
         assert_eq!(decided.get_outcome(), true);
         let status = SignedByDecider::check_decision(&decider, &input).unwrap();

--- a/ovm/src/lib.rs
+++ b/ovm/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod db;
 pub mod deciders;
 pub mod error;
 pub mod property_executor;
@@ -16,6 +17,7 @@ mod tests {
         Quantifier, WitnessFactory,
     };
     use bytes::Bytes;
+    use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     ///
     /// ```ignore
@@ -35,7 +37,7 @@ mod tests {
             })),
             WitnessFactory::new(Box::new(|bytes| bytes.clone())),
         )));
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided: Decision = decider.decide(&property, None).unwrap();
         assert_eq!(decided.get_outcome(), true);
     }
@@ -52,7 +54,7 @@ mod tests {
             })),
             WitnessFactory::new(Box::new(|_bytes| Bytes::from(&b"aaa"[..]))),
         )));
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided_result = decider.decide(&property, None);
         assert_eq!(decided_result.is_ok(), false);
     }
@@ -75,7 +77,7 @@ mod tests {
             })),
             WitnessFactory::new(Box::new(|bytes| bytes.clone())),
         )));
-        let decider: PropertyExecutor = Default::default();
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let decided: Decision = decider.decide(&property, None).unwrap();
         assert_eq!(decided.get_outcome(), true);
     }

--- a/ovm/src/lib.rs
+++ b/ovm/src/lib.rs
@@ -10,13 +10,18 @@ pub use self::property_executor::DecideMixin;
 #[cfg(test)]
 mod tests {
 
+    use crate::db::Message;
     use crate::deciders::preimage_exists_decider::Verifier;
+    use crate::deciders::SignVerifier;
     use crate::property_executor::PropertyExecutor;
     use crate::types::{
-        Decision, ForAllSuchThatInput, Integer, PreimageExistsInput, Property, PropertyFactory,
-        Quantifier, WitnessFactory,
+        AndDeciderInput, Decision, ForAllSuchThatInput, HasLowerNonceInput, Integer,
+        PreimageExistsInput, Property, PropertyFactory, Quantifier, SignedByInput, WitnessFactory,
     };
     use bytes::Bytes;
+    use ethereum_types::Address;
+    use ethsign::SecretKey;
+    use plasma_core::data_structure::abi::Decodable;
     use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     ///
@@ -82,4 +87,43 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 
+    /// state channel
+    #[test]
+    fn test_state_channel() {
+        let raw_key_alice =
+            hex::decode("c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3")
+                .unwrap();
+        let raw_key_bob =
+            hex::decode("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f")
+                .unwrap();
+        let secret_key_alice = SecretKey::from_raw(&raw_key_alice).unwrap();
+        let secret_key_bob = SecretKey::from_raw(&raw_key_bob).unwrap();
+        let message = Bytes::from("state_update");
+        let signature = SignVerifier::sign(&secret_key_bob, &message);
+        let alice: Address = secret_key_alice.public().address().into();
+        let bob: Address = secret_key_bob.public().address().into();
+        let _nonce = Integer(10);
+        let left_property = Property::ForAllSuchThatDecider(Box::new(ForAllSuchThatInput::new(
+            Quantifier::SignedByQuantifier(alice),
+            PropertyFactory::new(Box::new(|bytes| {
+                Property::HasLowerNonceDecider(HasLowerNonceInput::new(
+                    Message::from_abi(&bytes.to_vec()).unwrap(),
+                    Integer(11),
+                ))
+            })),
+            WitnessFactory::new(Box::new(|bytes| bytes.clone())),
+        )));
+        let right_property =
+            Property::SignedByDecider(SignedByInput::new(Bytes::from("state_update"), bob));
+        let property = Property::AndDecider(Box::new(AndDeciderInput::new(
+            left_property,
+            Bytes::from(""),
+            right_property,
+            signature,
+        )));
+
+        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
+        let decided: Decision = decider.decide(&property, None).unwrap();
+        assert_eq!(decided.get_outcome(), true);
+    }
 }

--- a/ovm/src/property_executor.rs
+++ b/ovm/src/property_executor.rs
@@ -1,9 +1,12 @@
 use crate::db::MessageDb;
 use crate::deciders::{
-    AndDecider, ForAllSuchThatDecider, NotDecider, PreimageExistsDecider, SignedByDecider,
+    AndDecider, ForAllSuchThatDecider, HasLowerNonceDecider, NotDecider, PreimageExistsDecider,
+    SignedByDecider,
 };
 use crate::error::Error;
-use crate::quantifiers::{IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier};
+use crate::quantifiers::{
+    IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier, SignedByQuantifier,
+};
 use crate::types::Decider;
 use crate::types::{Decision, Property, Quantifier, QuantifierResult};
 use bytes::Bytes;
@@ -71,6 +74,9 @@ where
                 ForAllSuchThatDecider::decide(self, input, witness)
             }
             Property::SignedByDecider(input) => SignedByDecider::decide(self, input, witness),
+            Property::HasLowerNonceDecider(input) => {
+                HasLowerNonceDecider::decide(self, input, witness)
+            }
             _ => panic!("not implemented!!"),
         }
     }
@@ -81,6 +87,9 @@ where
             }
             Quantifier::NonnegativeIntegerLessThanQuantifier(upper_bound) => {
                 NonnegativeIntegerLessThanQuantifier::get_all_quantified(*upper_bound)
+            }
+            Quantifier::SignedByQuantifier(signer) => {
+                SignedByQuantifier::get_all_quantified(self, *signer)
             }
             _ => panic!("not implemented!!"),
         }

--- a/ovm/src/quantifiers.rs
+++ b/ovm/src/quantifiers.rs
@@ -1,3 +1,5 @@
 pub mod integer_quantifiers;
+pub mod signed_by_quantifier;
 
 pub use self::integer_quantifiers::{IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier};
+pub use self::signed_by_quantifier::SignedByQuantifier;

--- a/ovm/src/quantifiers/signed_by_quantifier.rs
+++ b/ovm/src/quantifiers/signed_by_quantifier.rs
@@ -1,0 +1,32 @@
+use crate::property_executor::PropertyExecutor;
+use crate::types::QuantifierResult;
+use bytes::Bytes;
+use ethereum_types::Address;
+use plasma_core::data_structure::abi::Encodable;
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct SignedByQuantifier {}
+
+impl Default for SignedByQuantifier {
+    fn default() -> Self {
+        SignedByQuantifier {}
+    }
+}
+
+impl SignedByQuantifier {
+    pub fn get_all_quantified<KVS>(
+        decider: &PropertyExecutor<KVS>,
+        signed_by: Address,
+    ) -> QuantifierResult
+    where
+        KVS: KeyValueStore,
+    {
+        let messages = decider
+            .get_message_db()
+            .get_messages_signed_by(signed_by, None, None);
+        QuantifierResult::new(
+            messages.iter().map(|m| Bytes::from(m.to_abi())).collect(),
+            true,
+        )
+    }
+}

--- a/ovm/src/types.rs
+++ b/ovm/src/types.rs
@@ -6,5 +6,6 @@ pub use self::core::{
     QuantifierResult, WitnessFactory,
 };
 pub use self::inputs::{
-    AndDeciderInput, ForAllSuchThatInput, NotDeciderInput, PreimageExistsInput, SignedByInput,
+    AndDeciderInput, ChannelUpdateSignatureExistsDeciderInput, ForAllSuchThatInput,
+    HasLowerNonceInput, NotDeciderInput, PreimageExistsInput, SignedByInput,
 };

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -3,10 +3,11 @@ use super::inputs::{
 };
 use crate::error::Error;
 use crate::property_executor::PropertyExecutor;
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use ethabi::Token;
 use ethereum_types::{Address, H256};
 use plasma_core::data_structure::abi::Encodable;
+use plasma_db::traits::kvs::KeyValueStore;
 use std::sync::Arc;
 
 pub type DeciderId = Address;
@@ -20,6 +21,14 @@ pub struct Integer(pub u64);
 impl Integer {
     pub fn new(n: u64) -> Self {
         Integer(n)
+    }
+}
+
+impl From<Integer> for Bytes {
+    fn from(i: Integer) -> Self {
+        let mut buf = BytesMut::with_capacity(64);
+        buf.put_u64_le(i.0);
+        Bytes::from(buf.to_vec())
     }
 }
 
@@ -183,12 +192,15 @@ impl std::fmt::Debug for WitnessFactory {
 
 pub trait Decider {
     type Input;
-    fn decide(
-        decider: &PropertyExecutor,
+    fn decide<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
         input: &Self::Input,
         witness: Option<&Bytes>,
     ) -> Result<Decision, Error>;
-    fn check_decision(decider: &PropertyExecutor, input: &Self::Input) -> Result<Decision, Error>;
+    fn check_decision<T: KeyValueStore>(
+        decider: &PropertyExecutor<T>,
+        input: &Self::Input,
+    ) -> Result<Decision, Error>;
 }
 
 pub struct QuantifierResult {

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -1,11 +1,12 @@
 use super::inputs::{
-    AndDeciderInput, ForAllSuchThatInput, NotDeciderInput, PreimageExistsInput, SignedByInput,
+    AndDeciderInput, ChannelUpdateSignatureExistsDeciderInput, ForAllSuchThatInput,
+    HasLowerNonceInput, NotDeciderInput, PreimageExistsInput, SignedByInput,
 };
 use crate::error::Error;
 use crate::property_executor::PropertyExecutor;
 use bytes::{BufMut, Bytes, BytesMut};
 use ethabi::Token;
-use ethereum_types::{Address, H256};
+use ethereum_types::Address;
 use plasma_core::data_structure::abi::Encodable;
 use plasma_db::traits::kvs::KeyValueStore;
 use std::sync::Arc;
@@ -54,8 +55,10 @@ pub enum Property {
     PreimageExistsDecider(Box<PreimageExistsInput>),
     // message, public_key
     SignedByDecider(SignedByInput),
+    // message, nonce
+    HasLowerNonceDecider(HasLowerNonceInput),
     // channelId, nonce, participant
-    ChannelUpdateSignatureExistsDecider(H256, Integer, Address),
+    ChannelUpdateSignatureExistsDecider(ChannelUpdateSignatureExistsDeciderInput),
 }
 
 #[derive(Clone, Debug)]
@@ -64,6 +67,8 @@ pub enum Quantifier {
     IntegerRangeQuantifier(Integer, Integer),
     // 0 to upperBound
     NonnegativeIntegerLessThanQuantifier(Integer),
+    // signer
+    SignedByQuantifier(Address),
     // blocknumber, start and end
     IncludedCoinRangeQuantifier(Integer, Integer, Integer),
 }

--- a/ovm/src/types/inputs.rs
+++ b/ovm/src/types/inputs.rs
@@ -1,4 +1,5 @@
 use super::core::{Integer, Property, PropertyFactory, Quantifier, WitnessFactory};
+use crate::db::Message;
 use bytes::Bytes;
 use ethereum_types::{Address, H256};
 
@@ -121,14 +122,32 @@ impl SignedByInput {
 }
 
 #[derive(Clone, Debug)]
-pub struct ChannelUpdateSignatureExistsDeciderInput {
-    channel_id: H256,
+pub struct HasLowerNonceInput {
+    message: Message,
     nonce: Integer,
-    particilant: Address,
+}
+
+impl HasLowerNonceInput {
+    pub fn new(message: Message, nonce: Integer) -> Self {
+        HasLowerNonceInput { message, nonce }
+    }
+    pub fn get_message(&self) -> &Message {
+        &self.message
+    }
+    pub fn get_nonce(&self) -> Integer {
+        self.nonce
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChannelUpdateSignatureExistsDeciderInput {
+    pub channel_id: Bytes,
+    pub nonce: Integer,
+    pub particilant: Address,
 }
 
 impl ChannelUpdateSignatureExistsDeciderInput {
-    pub fn new(channel_id: H256, nonce: Integer, particilant: Address) -> Self {
+    pub fn new(channel_id: Bytes, nonce: Integer, particilant: Address) -> Self {
         ChannelUpdateSignatureExistsDeciderInput {
             channel_id,
             nonce,


### PR DESCRIPTION
## Task List

- [x] Add SignedByQuantifier
- [x] Add HasLowerNonceDecider
- [x] Add State Channel Exit Property

### State channel exit property.

https://github.com/cryptoeconomicslab/plasma-rust-framework/pull/143/files#diff-6fd1ca045cc7d855bedda67a8b02b05aR90-R128

```
CHANNEL_ID = '0x3423235fff'
MY_ADDRESS = '0x1234567800'
COUNTERPARTY_PARTICIPANT = '0x8765432100'
CHANNEL_NONCE = 10
stateChannelExitProperty = {
    predicate: AndDecider,
    input: {
        properties: [
            {
                predicate: ForAllSuchThatDecider
                input: {
                    quantifier: SignedByQuantifier,
                    parameters: {
                        channelId: CHANNEL_ID,
                        participantAddress: MY_ADDRESS
                    }
                },
                propertyFactory: (channelMessage) => {
                    return {
                        predicate: HasLowerNonceDecider,
                        input: {
                            nonce: CHANNEL_NONCE + 1
                        }
                    }
                }
            },
            {
                predicate: SignedByDecider,
                input: {
                    message: state update message of CHANNEL_ID and CHANNEL_NONCE,
                    public_key: COUNTERPARTY_PARTICIPANT
                }
            }
        ]
    }
}
```

Close #144 
