### PR TITLE
Remove property factory

### DIFF
--- a/abi-derive/src/lib.rs
+++ b/abi-derive/src/lib.rs
@@ -124,6 +124,9 @@ fn create_tokens(f: &syn::Field) -> proc_macro2::TokenStream {
             "Address" => quote! {
                 Token::Address(self.#ident)
             },
+            "bool" => quote! {
+                Token::Bool(self.#ident)
+            },
             _ => quote! {
                 Token::Tuple(self.#ident.to_tuple())
             },
@@ -153,6 +156,9 @@ fn create_param_type_token_stream(f: &syn::Field) -> proc_macro2::TokenStream {
             },
             "Address" => quote! {
                 ethabi::ParamType::Address
+            },
+            "bool" => quote! {
+                ethabi::ParamType::Bool
             },
             _ => quote! {
                 ethabi::ParamType::Tuple(#type_name::get_param_types())
@@ -185,6 +191,9 @@ fn create_parse_val_token_stream(
         },
         "Address" => quote! {
             let #ident: Address = tuple[#index].clone().to_address().unwrap();
+        },
+        "bool" => quote! {
+            let #ident: bool = tuple[#index].clone().to_bool().unwrap();
         },
         _ => quote! {
             let #ident: #type_name = #type_name::from_tuple(&tuple[#index].clone().to_tuple().unwrap()).unwrap();

--- a/abi-derive/src/lib.rs
+++ b/abi-derive/src/lib.rs
@@ -124,9 +124,6 @@ fn create_tokens(f: &syn::Field) -> proc_macro2::TokenStream {
             "Address" => quote! {
                 Token::Address(self.#ident)
             },
-            "bool" => quote! {
-                Token::Bool(self.#ident)
-            },
             _ => quote! {
                 Token::Tuple(self.#ident.to_tuple())
             },
@@ -156,9 +153,6 @@ fn create_param_type_token_stream(f: &syn::Field) -> proc_macro2::TokenStream {
             },
             "Address" => quote! {
                 ethabi::ParamType::Address
-            },
-            "bool" => quote! {
-                ethabi::ParamType::Bool
             },
             _ => quote! {
                 ethabi::ParamType::Tuple(#type_name::get_param_types())
@@ -191,9 +185,6 @@ fn create_parse_val_token_stream(
         },
         "Address" => quote! {
             let #ident: Address = tuple[#index].clone().to_address().unwrap();
-        },
-        "bool" => quote! {
-            let #ident: bool = tuple[#index].clone().to_bool().unwrap();
         },
         _ => quote! {
             let #ident: #type_name = #type_name::from_tuple(&tuple[#index].clone().to_tuple().unwrap()).unwrap();

--- a/clients/src/state_channel.rs
+++ b/clients/src/state_channel.rs
@@ -71,7 +71,7 @@ impl<KVS: KeyValueStore + DatabaseTrait> StateChannel<KVS> {
         channel_id: &Bytes,
         claim: &Property,
     ) -> Vec<ImplicationProofElement> {
-        let decider: PropertyExecutor<KVS> = Default::default();
+        let mut decider: PropertyExecutor<KVS> = Default::default();
         let decision: Decision = decider.decide(&claim).unwrap();
         if decision.get_outcome() {
             let channel_db: ChannelDb<KVS> = (&self.db).into();
@@ -87,7 +87,7 @@ impl<KVS: KeyValueStore + DatabaseTrait> StateChannel<KVS> {
         counter_party: Address,
     ) -> Option<Decision> {
         let property = self.get_exit_claim(channel_id, my_address, counter_party);
-        let decider: PropertyExecutor<KVS> = Default::default();
+        let mut decider: PropertyExecutor<KVS> = Default::default();
         decider.decide(&property).ok()
     }
 

--- a/contract-wrapper/src/main.rs
+++ b/contract-wrapper/src/main.rs
@@ -2,7 +2,7 @@ extern crate serde;
 
 use contract_wrapper::universal_decision_contract_adaptor::UniversalDecisionContractAdaptor;
 use ethabi::Contract as ContractABI;
-use ovm::types::{Placeholder, Property, SignedByInput};
+use ovm::types::{InputType, Property, SignedByInput};
 use std::fs::File;
 use std::io::BufReader;
 use web3::types::Address;
@@ -20,10 +20,8 @@ fn main() {
 
     let from: Address = "ce397e30544d737195a341291675ec1ecaf19b13".parse().unwrap();
     let input = SignedByInput::new(
-        Placeholder::new("message"),
-        Placeholder::new("public_key"),
-        //        b"012345678"[..].into(),
-        //        "1a50faDFab6b21AaaED82bb17A541993304786E7".parse().unwrap(),
+        InputType::ConstantBytes(b"012345678"[..].into()),
+        InputType::ConstantAddress("1a50faDFab6b21AaaED82bb17A541993304786E7".parse().unwrap()),
     );
     let property = Property::SignedByDecider(input);
 

--- a/contract-wrapper/src/main.rs
+++ b/contract-wrapper/src/main.rs
@@ -2,8 +2,7 @@ extern crate serde;
 
 use contract_wrapper::universal_decision_contract_adaptor::UniversalDecisionContractAdaptor;
 use ethabi::Contract as ContractABI;
-use ovm::types::core::Property;
-use ovm::types::inputs::SignedByInput;
+use ovm::types::{Placeholder, Property, SignedByInput};
 use std::fs::File;
 use std::io::BufReader;
 use web3::types::Address;
@@ -21,8 +20,10 @@ fn main() {
 
     let from: Address = "ce397e30544d737195a341291675ec1ecaf19b13".parse().unwrap();
     let input = SignedByInput::new(
-        b"012345678"[..].into(),
-        "1a50faDFab6b21AaaED82bb17A541993304786E7".parse().unwrap(),
+        Placeholder::new("message"),
+        Placeholder::new("public_key"),
+        //        b"012345678"[..].into(),
+        //        "1a50faDFab6b21AaaED82bb17A541993304786E7".parse().unwrap(),
     );
     let property = Property::SignedByDecider(input);
 

--- a/ovm/src/db/range_at_block_db.rs
+++ b/ovm/src/db/range_at_block_db.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::types::{IncludedAtBlockInput, Integer, PlasmaDataBlock, Witness};
+use crate::types::{Integer, PlasmaDataBlock, Witness};
 use bytes::Bytes;
 use plasma_core::data_structure::abi::{Decodable, Encodable};
 use plasma_db::traits::kvs::KeyValueStore;

--- a/ovm/src/db/range_at_block_db.rs
+++ b/ovm/src/db/range_at_block_db.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::types::{IncludedAtBlockInput, Witness};
+use crate::types::{IncludedAtBlockInput, Integer, PlasmaDataBlock, Witness};
 use bytes::Bytes;
 use plasma_core::data_structure::abi::{Decodable, Encodable};
 use plasma_db::traits::kvs::KeyValueStore;
@@ -16,33 +16,32 @@ impl<'a, KVS: KeyValueStore> RangeAtBlockDb<'a, KVS> {
     }
     pub fn store_witness(
         &self,
-        input: &IncludedAtBlockInput,
+        block_number: Integer,
+        plasma_data_block: &PlasmaDataBlock,
         witness: &Witness,
     ) -> Result<(), Error> {
         self.db
             .bucket(&Bytes::from(&b"range_at_block"[..]))
-            .bucket(&input.get_block_number().into())
+            .bucket(&block_number.into())
             .put(
-                input
-                    .get_plasma_data_block()
-                    .get_updated_range()
-                    .get_start(),
-                input.get_plasma_data_block().get_updated_range().get_end(),
+                plasma_data_block.get_updated_range().get_start(),
+                plasma_data_block.get_updated_range().get_end(),
                 &witness.to_abi(),
             )
             .map_err::<Error, _>(Into::into)
     }
-    pub fn get_witness(&self, input: &IncludedAtBlockInput) -> Result<Witness, Error> {
+    pub fn get_witness(
+        &self,
+        block_number: Integer,
+        plasma_data_block: &PlasmaDataBlock,
+    ) -> Result<Witness, Error> {
         let result = self
             .db
             .bucket(&Bytes::from(&b"range_at_block"[..]))
-            .bucket(&input.get_block_number().into())
+            .bucket(&block_number.into())
             .get(
-                input
-                    .get_plasma_data_block()
-                    .get_updated_range()
-                    .get_start(),
-                input.get_plasma_data_block().get_updated_range().get_end(),
+                plasma_data_block.get_updated_range().get_start(),
+                plasma_data_block.get_updated_range().get_end(),
             )
             .map_err::<Error, _>(Into::into)?;
         if result.len() == 0 {

--- a/ovm/src/deciders/and_decider.rs
+++ b/ovm/src/deciders/and_decider.rs
@@ -43,29 +43,34 @@ impl Decider for AndDecider {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use crate::db::HashPreimageDb;
-    use crate::deciders::preimage_exists_decider::Verifier;
     use crate::property_executor::PropertyExecutor;
-    use crate::types::{AndDeciderInput, Decision, PreimageExistsInput, Property, Witness};
+    use crate::types::{
+        AndDeciderInput, Decision, InputType, PreimageExistsInput, Property, Witness,
+    };
+    use crate::utils::static_hash;
     use bytes::Bytes;
     use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
         let left_preimage = Bytes::from("left");
-        let left_hash = Verifier::static_hash(&left_preimage);
+        let left_hash = static_hash(&left_preimage);
         let left_witness = Witness::Bytes(left_preimage);
         let right_preimage = Bytes::from("right");
-        let right_hash = Verifier::static_hash(&right_preimage);
+        let right_hash = static_hash(&right_preimage);
         let right_witness = Witness::Bytes(right_preimage);
-        let left = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(left_hash)));
-        let right = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(right_hash)));
+        let left = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(
+            InputType::ConstantH256(left_hash),
+        )));
+        let right = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(
+            InputType::ConstantH256(right_hash),
+        )));
         let input = AndDeciderInput::new(left, right);
         let and_decider = Property::AndDecider(Box::new(input.clone()));
-        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
+        let mut decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let db = HashPreimageDb::new(decider.get_db());
         assert!(db.store_witness(left_hash, &left_witness).is_ok());
         assert!(db.store_witness(right_hash, &right_witness).is_ok());
@@ -73,4 +78,3 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
-*/

--- a/ovm/src/deciders/and_decider.rs
+++ b/ovm/src/deciders/and_decider.rs
@@ -21,7 +21,7 @@ impl Default for AndDecider {
 impl Decider for AndDecider {
     type Input = AndDeciderInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &AndDeciderInput,
     ) -> Result<Decision, Error> {
         let left_decision = input.get_left().decide(decider)?;
@@ -43,6 +43,7 @@ impl Decider for AndDecider {
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
     use crate::db::HashPreimageDb;
@@ -72,3 +73,4 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
+*/

--- a/ovm/src/deciders/for_all_such_that_decider.rs
+++ b/ovm/src/deciders/for_all_such_that_decider.rs
@@ -30,7 +30,6 @@ impl ForAllSuchThatDecider {
                 justification.extend(decision.get_implication_proof().clone())
             }
         }
-
         Ok(Decision::new(!false_decision.get_outcome(), justification))
     }
 }
@@ -64,6 +63,7 @@ impl Decider for ForAllSuchThatDecider {
                 decider,
                 // no_cache,
             );
+
             if let Ok(decision) = decision_result {
                 if !decision.get_outcome() {
                     false_decision = decision;

--- a/ovm/src/deciders/for_all_such_that_decider.rs
+++ b/ovm/src/deciders/for_all_such_that_decider.rs
@@ -43,7 +43,7 @@ impl Default for ForAllSuchThatDecider {
 impl Decider for ForAllSuchThatDecider {
     type Input = ForAllSuchThatInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &ForAllSuchThatInput,
     ) -> Result<Decision, Error> {
         let quantifier_result: QuantifierResult =
@@ -53,12 +53,9 @@ impl Decider for ForAllSuchThatDecider {
         let mut false_decision: Decision = Decision::new(false, vec![]);
         let mut true_decisions: Vec<Decision> = vec![];
         for res in quantifier_result.get_results() {
-            let prop: Property = input
-                .get_property_factory()
-                .clone()
-                .unwrap()
-                .call(res.clone());
+            let prop: Property = input.get_property().clone();
             let _no_cache = false;
+            decider.set_replace(input.get_placeholder().clone(), res.clone());
             let decision_result = prop.decide(
                 decider,
                 // no_cache,
@@ -84,6 +81,7 @@ impl Decider for ForAllSuchThatDecider {
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
     use super::ForAllSuchThatDecider;
@@ -125,3 +123,4 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
+*/

--- a/ovm/src/deciders/has_lower_nonce.rs
+++ b/ovm/src/deciders/has_lower_nonce.rs
@@ -29,7 +29,7 @@ impl Decider for HasLowerNonceDecider {
             decider.replace(input.get_message()),
             decider.replace(input.get_nonce()),
         ) {
-            if message.nonce < *nonce {
+            if message.nonce < nonce {
                 Ok(Decision::new(
                     true,
                     vec![ImplicationProofElement::new(

--- a/ovm/src/deciders/included_at_block_decider.rs
+++ b/ovm/src/deciders/included_at_block_decider.rs
@@ -2,7 +2,8 @@ use crate::db::RangeAtBlockDb;
 use crate::error::{Error, ErrorKind};
 use crate::property_executor::PropertyExecutor;
 use crate::types::{
-    Decider, Decision, ImplicationProofElement, IncludedAtBlockInput, Property, Witness,
+    Decider, Decision, ImplicationProofElement, IncludedAtBlockInput, Property,
+    QuantifierResultItem, Witness,
 };
 use bytes::Bytes;
 use merkle_interval_tree::{MerkleIntervalNode, MerkleIntervalTree};
@@ -21,35 +22,41 @@ impl Default for IncludedAtBlockDecider {
 impl Decider for IncludedAtBlockDecider {
     type Input = IncludedAtBlockInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &IncludedAtBlockInput,
     ) -> Result<Decision, Error> {
         let db: RangeAtBlockDb<T> = RangeAtBlockDb::new(decider.get_range_db());
-        let witness = db.get_witness(input)?;
-        if let Witness::IncludedInIntervalTreeAtBlock(inclusion_proof, _) = witness.clone() {
-            let plasma_data_block = input.get_plasma_data_block();
-            let leaf = MerkleIntervalNode::Leaf {
-                end: plasma_data_block.get_updated_range().get_end(),
-                data: Bytes::from(plasma_data_block.get_property().to_abi()),
-            };
-            let inclusion_bounds_result = MerkleIntervalTree::verify(
-                &leaf,
-                plasma_data_block.get_index(),
-                inclusion_proof,
-                plasma_data_block.get_root(),
-            );
-            if inclusion_bounds_result.is_err() {
-                return Err(Error::from(ErrorKind::CannotDecide));
+        if let (
+            QuantifierResultItem::Integer(block_number),
+            QuantifierResultItem::PlasmaDataBlock(plasma_data_block),
+        ) = (
+            decider.replace(input.get_block_number()),
+            decider.replace(input.get_plasma_data_block()),
+        ) {
+            let witness = db.get_witness(*block_number, plasma_data_block)?;
+            if let Witness::IncludedInIntervalTreeAtBlock(inclusion_proof, _) = witness.clone() {
+                let leaf = MerkleIntervalNode::Leaf {
+                    end: plasma_data_block.get_updated_range().get_end(),
+                    data: Bytes::from(plasma_data_block.get_property().to_abi()),
+                };
+                let inclusion_bounds_result = MerkleIntervalTree::verify(
+                    &leaf,
+                    plasma_data_block.get_index(),
+                    inclusion_proof,
+                    plasma_data_block.get_root(),
+                );
+                if inclusion_bounds_result.is_err() {
+                    return Err(Error::from(ErrorKind::CannotDecide));
+                }
+                return Ok(Decision::new(
+                    true,
+                    vec![ImplicationProofElement::new(
+                        Property::IncludedAtBlockDecider(Box::new(input.clone())),
+                        Some(witness.clone()),
+                    )],
+                ));
             }
-            Ok(Decision::new(
-                true,
-                vec![ImplicationProofElement::new(
-                    Property::IncludedAtBlockDecider(Box::new(input.clone())),
-                    Some(witness.clone()),
-                )],
-            ))
-        } else {
-            panic!("invalid witness")
         }
+        panic!("invalid input")
     }
 }

--- a/ovm/src/deciders/included_at_block_decider.rs
+++ b/ovm/src/deciders/included_at_block_decider.rs
@@ -33,7 +33,7 @@ impl Decider for IncludedAtBlockDecider {
             decider.replace(input.get_block_number()),
             decider.replace(input.get_plasma_data_block()),
         ) {
-            let witness = db.get_witness(*block_number, plasma_data_block)?;
+            let witness = db.get_witness(block_number, &plasma_data_block)?;
             if let Witness::IncludedInIntervalTreeAtBlock(inclusion_proof, _) = witness.clone() {
                 let leaf = MerkleIntervalNode::Leaf {
                     end: plasma_data_block.get_updated_range().get_end(),

--- a/ovm/src/deciders/not_decider.rs
+++ b/ovm/src/deciders/not_decider.rs
@@ -21,7 +21,7 @@ impl Default for NotDecider {
 impl Decider for NotDecider {
     type Input = NotDeciderInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &NotDeciderInput,
     ) -> Result<Decision, Error> {
         let decision = input.get_property().decide(decider)?;

--- a/ovm/src/deciders/or_decider.rs
+++ b/ovm/src/deciders/or_decider.rs
@@ -50,28 +50,28 @@ impl Decider for OrDecider {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use crate::db::HashPreimageDb;
-    use crate::deciders::preimage_exists_decider::Verifier;
     use crate::property_executor::PropertyExecutor;
     use crate::types::{
-        Decision, NotDeciderInput, OrDeciderInput, PreimageExistsInput, Property, Witness,
+        Decision, InputType, NotDeciderInput, OrDeciderInput, PreimageExistsInput, Property,
+        Witness,
     };
+    use crate::utils::static_hash;
     use bytes::Bytes;
     use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
-        let left_hash = Verifier::static_hash(&Bytes::from("left"));
-        let right_hash = Verifier::static_hash(&Bytes::from("right"));
+        let left_hash = static_hash(&Bytes::from("left"));
+        let right_hash = static_hash(&Bytes::from("right"));
         let left = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(
-            Verifier::static_hash(&Bytes::from("left")),
+            InputType::ConstantH256(static_hash(&Bytes::from("left"))),
         )));
         let left_witness = Witness::Bytes(Bytes::from("left"));
         let right = Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(
-            Verifier::static_hash(&Bytes::from("right")),
+            InputType::ConstantH256(static_hash(&Bytes::from("right"))),
         )));
         let right_witness = Witness::Bytes(Bytes::from("right"));
         let input = OrDeciderInput::new(
@@ -79,7 +79,7 @@ mod tests {
             Property::NotDecider(Box::new(NotDeciderInput::new(right))),
         );
         let or_decider = Property::OrDecider(Box::new(input.clone()));
-        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
+        let mut decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let db = HashPreimageDb::new(decider.get_db());
         assert!(db.store_witness(left_hash, &left_witness).is_ok());
         assert!(db.store_witness(right_hash, &right_witness).is_ok());
@@ -87,4 +87,3 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
-*/

--- a/ovm/src/deciders/or_decider.rs
+++ b/ovm/src/deciders/or_decider.rs
@@ -21,7 +21,7 @@ impl Default for OrDecider {
 impl Decider for OrDecider {
     type Input = OrDeciderInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &OrDeciderInput,
     ) -> Result<Decision, Error> {
         let left_decision = input.get_left().decide(decider);
@@ -50,6 +50,7 @@ impl Decider for OrDecider {
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
     use crate::db::HashPreimageDb;
@@ -86,3 +87,4 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
+*/

--- a/ovm/src/deciders/preimage_exists_decider.rs
+++ b/ovm/src/deciders/preimage_exists_decider.rs
@@ -35,18 +35,17 @@ impl Decider for PreimageExistsDecider {
         let db: HashPreimageDb<T> = HashPreimageDb::new(decider.get_db());
         if let QuantifierResultItem::H256(hash) = decider.replace(input.get_hash()) {
             let witness = db.get_witness(hash)?;
-            if let Witness::Bytes(preimage) = witness {
-                if Verifier::hash(&preimage) != hash {
-                    return Err(Error::from(ErrorKind::InvalidPreimage));
-                }
-                return Ok(Decision::new(
-                    true,
-                    vec![ImplicationProofElement::new(
-                        Property::PreimageExistsDecider(Box::new(input.clone())),
-                        Some(Witness::Bytes(preimage)),
-                    )],
-                ));
+            let preimage = witness.to_bytes();
+            if Verifier::hash(preimage) != hash {
+                return Err(Error::from(ErrorKind::InvalidPreimage));
             }
+            return Ok(Decision::new(
+                true,
+                vec![ImplicationProofElement::new(
+                    Property::PreimageExistsDecider(Box::new(input.clone())),
+                    Some(Witness::Bytes(preimage.clone())),
+                )],
+            ));
         }
         panic!("invalid witness")
     }

--- a/ovm/src/deciders/preimage_exists_decider.rs
+++ b/ovm/src/deciders/preimage_exists_decider.rs
@@ -5,25 +5,16 @@ use crate::types::{
     Decider, Decision, ImplicationProofElement, PreimageExistsInput, Property,
     QuantifierResultItem, Witness,
 };
+use crate::utils::static_hash;
 use bytes::Bytes;
 use ethereum_types::H256;
 use plasma_db::traits::kvs::KeyValueStore;
-use tiny_keccak::Keccak;
 
 pub struct Verifier {}
 
 impl Verifier {
     pub fn hash(preimage: &Bytes) -> H256 {
-        Self::static_hash(preimage)
-    }
-    pub fn static_hash(preimage: &Bytes) -> H256 {
-        let mut sha3 = Keccak::new_sha3_256();
-
-        sha3.update(preimage.as_ref());
-
-        let mut res: [u8; 32] = [0; 32];
-        sha3.finalize(&mut res);
-        H256::from(res)
+        static_hash(preimage)
     }
 }
 
@@ -43,9 +34,9 @@ impl Decider for PreimageExistsDecider {
     ) -> Result<Decision, Error> {
         let db: HashPreimageDb<T> = HashPreimageDb::new(decider.get_db());
         if let QuantifierResultItem::H256(hash) = decider.replace(input.get_hash()) {
-            let witness = db.get_witness(*hash)?;
+            let witness = db.get_witness(hash)?;
             if let Witness::Bytes(preimage) = witness {
-                if Verifier::hash(&preimage) != *hash {
+                if Verifier::hash(&preimage) != hash {
                     return Err(Error::from(ErrorKind::InvalidPreimage));
                 }
                 return Ok(Decision::new(
@@ -61,28 +52,26 @@ impl Decider for PreimageExistsDecider {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use crate::db::HashPreimageDb;
-    use crate::deciders::preimage_exists_decider::Verifier;
     use crate::property_executor::PropertyExecutor;
-    use crate::types::{Decision, PreimageExistsInput, Property, Witness};
+    use crate::types::{Decision, InputType, PreimageExistsInput, Property, Witness};
+    use crate::utils::static_hash;
     use bytes::Bytes;
     use plasma_db::impls::kvs::CoreDbLevelDbImpl;
 
     #[test]
     fn test_decide() {
         let preimage = Bytes::from("left");
-        let hash = Verifier::static_hash(&preimage);
-        let input = PreimageExistsInput::new(hash);
+        let hash = static_hash(&preimage);
+        let input = PreimageExistsInput::new(InputType::ConstantH256(hash));
         let property = Property::PreimageExistsDecider(Box::new(input.clone()));
         let witness = Witness::Bytes(preimage);
-        let decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
+        let mut decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
         let db = HashPreimageDb::new(decider.get_db());
         assert!(db.store_witness(hash, &witness).is_ok());
         let decided: Decision = decider.decide(&property).unwrap();
         assert_eq!(decided.get_outcome(), true);
     }
 }
-*/

--- a/ovm/src/deciders/signed_by_decider.rs
+++ b/ovm/src/deciders/signed_by_decider.rs
@@ -87,7 +87,7 @@ mod tests {
     use super::Verifier;
     use crate::db::SignedByDb;
     use crate::property_executor::PropertyExecutor;
-    use crate::types::{Decision, InputType, Property, SignedByInput, Witness};
+    use crate::types::{Decision, InputType, Property, SignedByInput};
     use bytes::Bytes;
     use ethereum_types::Address;
     use ethsign::SecretKey;

--- a/ovm/src/deciders/signed_by_decider.rs
+++ b/ovm/src/deciders/signed_by_decider.rs
@@ -1,7 +1,10 @@
 use crate::db::SignedByDb;
 use crate::error::{Error, ErrorKind};
 use crate::property_executor::PropertyExecutor;
-use crate::types::{Decider, Decision, ImplicationProofElement, Property, SignedByInput, Witness};
+use crate::types::{
+    Decider, Decision, ImplicationProofElement, Property, QuantifierResultItem, SignedByInput,
+    Witness,
+};
 use bytes::Bytes;
 use ethereum_types::{Address, H256};
 use ethsign::{SecretKey, Signature};
@@ -61,27 +64,33 @@ impl Default for SignedByDecider {
 impl Decider for SignedByDecider {
     type Input = SignedByInput;
     fn decide<T: KeyValueStore>(
-        decider: &PropertyExecutor<T>,
+        decider: &mut PropertyExecutor<T>,
         input: &SignedByInput,
     ) -> Result<Decision, Error> {
         let db: SignedByDb<T> = SignedByDb::new(decider.get_db());
-        let signed_by_message = db.get_witness(input.get_public_key(), input.get_message())?;
-        if Verifier::recover(&signed_by_message.signature, input.get_message())
-            != input.get_public_key()
-        {
-            return Err(Error::from(ErrorKind::InvalidPreimage));
-        }
+        if let (QuantifierResultItem::Bytes(message), QuantifierResultItem::Address(public_key)) = (
+            decider.replace(input.get_message()),
+            decider.replace(input.get_public_key()),
+        ) {
+            let signed_by_message = db.get_witness(*public_key, &message)?;
+            if Verifier::recover(&signed_by_message.signature, &message) != *public_key {
+                return Err(Error::from(ErrorKind::InvalidPreimage));
+            }
 
-        Ok(Decision::new(
-            true,
-            vec![ImplicationProofElement::new(
-                Property::SignedByDecider(input.clone()),
-                Some(Witness::Bytes(signed_by_message.signature)),
-            )],
-        ))
+            Ok(Decision::new(
+                true,
+                vec![ImplicationProofElement::new(
+                    Property::SignedByDecider(input.clone()),
+                    Some(Witness::Bytes(signed_by_message.signature)),
+                )],
+            ))
+        } else {
+            panic!("invalid witness");
+        }
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
     use super::Verifier;
@@ -115,3 +124,4 @@ mod tests {
         assert_eq!(decided.get_outcome(), true);
     }
 }
+*/

--- a/ovm/src/lib.rs
+++ b/ovm/src/lib.rs
@@ -21,7 +21,7 @@ mod tests {
     use crate::statements::{create_plasma_property, create_state_channel_property};
     use crate::types::{
         Decision, ForAllSuchThatInput, InputType, Integer, IntegerRangeQuantifierInput,
-        PreimageExistsInput, Property, Quantifier, QuantifierResultItem, Witness,
+        PreimageExistsInput, Property, Quantifier, Witness,
     };
     use crate::utils::static_hash;
     use bytes::Bytes;

--- a/ovm/src/lib.rs
+++ b/ovm/src/lib.rs
@@ -12,6 +12,7 @@ pub mod utils;
 
 pub use self::property_executor::DecideMixin;
 
+/*
 #[cfg(test)]
 mod tests {
 
@@ -157,3 +158,4 @@ mod tests {
         assert!(result.is_err());
     }
 }
+*/

--- a/ovm/src/property_executor.rs
+++ b/ovm/src/property_executor.rs
@@ -69,7 +69,7 @@ where
             InputType::Placeholder(placeholder) => self.variables.get(placeholder).unwrap().clone(),
             InputType::ConstantAddress(constant) => QuantifierResultItem::Address(*constant),
             InputType::ConstantBytes(constant) => QuantifierResultItem::Bytes(constant.clone()),
-            InputType::ConstantH256(constant) => QuantifierResultItem::H256(constant.clone()),
+            InputType::ConstantH256(constant) => QuantifierResultItem::H256(*constant),
             InputType::ConstantInteger(constant) => QuantifierResultItem::Integer(*constant),
             InputType::ConstantRange(constant) => QuantifierResultItem::Range(*constant),
         }

--- a/ovm/src/quantifiers.rs
+++ b/ovm/src/quantifiers.rs
@@ -1,7 +1,9 @@
 pub mod block_range_quantifier;
+pub mod hash_quantifier;
 pub mod integer_quantifiers;
 pub mod signed_by_quantifier;
 
 pub use self::block_range_quantifier::BlockRangeQuantifier;
+pub use self::hash_quantifier::HashQuantifier;
 pub use self::integer_quantifiers::{IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier};
 pub use self::signed_by_quantifier::SignedByQuantifier;

--- a/ovm/src/quantifiers/block_range_quantifier.rs
+++ b/ovm/src/quantifiers/block_range_quantifier.rs
@@ -45,7 +45,7 @@ impl BlockRangeQuantifier {
             let result = decider
                 .get_range_db()
                 .bucket(&Bytes::from("range_at_block"))
-                .bucket(&(*block_number).into())
+                .bucket(&(block_number).into())
                 .get(range.get_start(), range.get_end())
                 .unwrap();
             let sum = result

--- a/ovm/src/quantifiers/block_range_quantifier.rs
+++ b/ovm/src/quantifiers/block_range_quantifier.rs
@@ -38,52 +38,45 @@ impl BlockRangeQuantifier {
     where
         KVS: KeyValueStore,
     {
-        if let (QuantifierResultItem::Integer(block_number), QuantifierResultItem::Range(range)) = (
-            decider.replace(&input.block_number),
-            decider.replace(&input.coin_range),
-        ) {
-            let result = decider
-                .get_range_db()
-                .bucket(&Bytes::from("range_at_block"))
-                .bucket(&(block_number).into())
-                .get(range.get_start(), range.get_end())
-                .unwrap();
-            let sum = result
-                .iter()
-                .filter_map(|r| r.get_intersection(range.get_start(), range.get_end()))
-                .fold(0, |acc, r| acc + r.get_end() - r.get_start());
-            let mut full_range_included: bool = sum == (range.get_end() - range.get_start());
-            let plasma_data_blocks: Vec<PlasmaDataBlock> = result
-                .iter()
-                .map(|r| Witness::from_abi(r.get_value()).unwrap())
-                .filter_map(move |w| {
-                    if let Witness::IncludedInIntervalTreeAtBlock(
-                        inclusion_proof,
-                        plasma_data_block,
-                    ) = w
-                    {
-                        if plasma_data_block.get_is_included() {
-                            Some(plasma_data_block.clone())
-                        } else {
-                            if !Self::verify_exclusion(&plasma_data_block, &inclusion_proof) {
-                                full_range_included = false
-                            }
-                            None
-                        }
+        let block_number = decider.replace(&input.block_number).to_integer();
+        let range = decider.replace(&input.coin_range).to_range();
+        let result = decider
+            .get_range_db()
+            .bucket(&Bytes::from("range_at_block"))
+            .bucket(&(block_number).into())
+            .get(range.get_start(), range.get_end())
+            .unwrap();
+        let sum = result
+            .iter()
+            .filter_map(|r| r.get_intersection(range.get_start(), range.get_end()))
+            .fold(0, |acc, r| acc + r.get_end() - r.get_start());
+        let mut full_range_included: bool = sum == (range.get_end() - range.get_start());
+        let plasma_data_blocks: Vec<PlasmaDataBlock> = result
+            .iter()
+            .map(|r| Witness::from_abi(r.get_value()).unwrap())
+            .filter_map(move |w| {
+                if let Witness::IncludedInIntervalTreeAtBlock(inclusion_proof, plasma_data_block) =
+                    w
+                {
+                    if plasma_data_block.get_is_included() {
+                        Some(plasma_data_block.clone())
                     } else {
-                        panic!("invalid witness")
+                        if !Self::verify_exclusion(&plasma_data_block, &inclusion_proof) {
+                            full_range_included = false
+                        }
+                        None
                     }
-                })
-                .collect();
-            QuantifierResult::new(
-                plasma_data_blocks
-                    .iter()
-                    .map(|p| QuantifierResultItem::PlasmaDataBlock(p.clone()))
-                    .collect(),
-                full_range_included,
-            )
-        } else {
-            panic!("invalid input")
-        }
+                } else {
+                    panic!("invalid witness")
+                }
+            })
+            .collect();
+        QuantifierResult::new(
+            plasma_data_blocks
+                .iter()
+                .map(|p| QuantifierResultItem::PlasmaDataBlock(p.clone()))
+                .collect(),
+            full_range_included,
+        )
     }
 }

--- a/ovm/src/quantifiers/hash_quantifier.rs
+++ b/ovm/src/quantifiers/hash_quantifier.rs
@@ -1,0 +1,31 @@
+use crate::property_executor::PropertyExecutor;
+use crate::types::{InputType, Integer, QuantifierResult, QuantifierResultItem};
+use crate::utils::static_hash;
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct HashQuantifier {}
+
+impl Default for HashQuantifier {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl HashQuantifier {
+    pub fn get_all_quantified<KVS: KeyValueStore>(
+        decider: &PropertyExecutor<KVS>,
+        placeholder: &InputType,
+    ) -> QuantifierResult {
+        if let QuantifierResultItem::Integer(preimage) = decider.replace(&placeholder) {
+            if preimage < Integer(0) {
+                panic!("preimage shouldn't negative value.");
+            }
+            QuantifierResult::new(
+                vec![QuantifierResultItem::H256(static_hash(&preimage.into()))],
+                true,
+            )
+        } else {
+            panic!("invalid input")
+        }
+    }
+}

--- a/ovm/src/quantifiers/hash_quantifier.rs
+++ b/ovm/src/quantifiers/hash_quantifier.rs
@@ -1,5 +1,5 @@
 use crate::property_executor::PropertyExecutor;
-use crate::types::{InputType, Integer, QuantifierResult, QuantifierResultItem};
+use crate::types::{InputType, QuantifierResult, QuantifierResultItem};
 use crate::utils::static_hash;
 use plasma_db::traits::kvs::KeyValueStore;
 
@@ -16,16 +16,10 @@ impl HashQuantifier {
         decider: &PropertyExecutor<KVS>,
         placeholder: &InputType,
     ) -> QuantifierResult {
-        if let QuantifierResultItem::Integer(preimage) = decider.replace(&placeholder) {
-            if preimage < Integer(0) {
-                panic!("preimage shouldn't negative value.");
-            }
-            QuantifierResult::new(
-                vec![QuantifierResultItem::H256(static_hash(&preimage.into()))],
-                true,
-            )
-        } else {
-            panic!("invalid input")
-        }
+        let preimage = decider.replace(&placeholder).to_integer();
+        QuantifierResult::new(
+            vec![QuantifierResultItem::H256(static_hash(&preimage.into()))],
+            true,
+        )
     }
 }

--- a/ovm/src/quantifiers/integer_quantifiers.rs
+++ b/ovm/src/quantifiers/integer_quantifiers.rs
@@ -1,6 +1,6 @@
 use crate::property_executor::PropertyExecutor;
 use crate::types::{
-    Integer, IntegerRangeQuantifierInput, Placeholder, QuantifierResult, QuantifierResultItem,
+    InputType, Integer, IntegerRangeQuantifierInput, QuantifierResult, QuantifierResultItem,
 };
 use plasma_db::traits::kvs::KeyValueStore;
 
@@ -50,10 +50,10 @@ impl Default for NonnegativeIntegerLessThanQuantifier {
 impl NonnegativeIntegerLessThanQuantifier {
     pub fn get_all_quantified<KVS: KeyValueStore>(
         decider: &PropertyExecutor<KVS>,
-        placeholder: &Placeholder,
+        placeholder: &InputType,
     ) -> QuantifierResult {
         if let QuantifierResultItem::Integer(upper_bound) = decider.replace(&placeholder) {
-            if *upper_bound < Integer(0) {
+            if upper_bound < Integer(0) {
                 panic!("upper_bound shouldn't negative value.");
             }
             QuantifierResult::new(get_range(0, upper_bound.0), true)

--- a/ovm/src/quantifiers/integer_quantifiers.rs
+++ b/ovm/src/quantifiers/integer_quantifiers.rs
@@ -24,17 +24,12 @@ impl IntegerRangeQuantifier {
         decider: &PropertyExecutor<KVS>,
         input: &IntegerRangeQuantifierInput,
     ) -> QuantifierResult {
-        if let (QuantifierResultItem::Integer(start), QuantifierResultItem::Integer(end)) = (
-            decider.replace(input.get_start()),
-            decider.replace(input.get_end()),
-        ) {
-            if end < start {
-                panic!("invalid start and end");
-            }
-            QuantifierResult::new(get_range(start.0, end.0), true)
-        } else {
-            panic!("invalid input");
+        let start = decider.replace(input.get_start()).to_integer();
+        let end = decider.replace(input.get_end()).to_integer();
+        if end < start {
+            panic!("invalid start and end");
         }
+        QuantifierResult::new(get_range(start.0, end.0), true)
     }
 }
 
@@ -52,13 +47,10 @@ impl NonnegativeIntegerLessThanQuantifier {
         decider: &PropertyExecutor<KVS>,
         placeholder: &InputType,
     ) -> QuantifierResult {
-        if let QuantifierResultItem::Integer(upper_bound) = decider.replace(&placeholder) {
-            if upper_bound < Integer(0) {
-                panic!("upper_bound shouldn't negative value.");
-            }
-            QuantifierResult::new(get_range(0, upper_bound.0), true)
-        } else {
-            panic!("invalid input")
+        let upper_bound = decider.replace(&placeholder).to_integer();
+        if upper_bound < Integer(0) {
+            panic!("upper_bound shouldn't negative value.");
         }
+        QuantifierResult::new(get_range(0, upper_bound.0), true)
     }
 }

--- a/ovm/src/quantifiers/signed_by_quantifier.rs
+++ b/ovm/src/quantifiers/signed_by_quantifier.rs
@@ -1,7 +1,6 @@
 use crate::db::SignedByDb;
 use crate::property_executor::PropertyExecutor;
-use crate::types::{Placeholder, QuantifierResult, QuantifierResultItem};
-use ethereum_types::Address;
+use crate::types::{InputType, QuantifierResult, QuantifierResultItem};
 use plasma_db::traits::kvs::KeyValueStore;
 
 pub struct SignedByQuantifier {}
@@ -15,14 +14,14 @@ impl Default for SignedByQuantifier {
 impl SignedByQuantifier {
     pub fn get_all_quantified<KVS>(
         decider: &PropertyExecutor<KVS>,
-        signed_by: &Placeholder,
+        signed_by: &InputType,
     ) -> QuantifierResult
     where
         KVS: KeyValueStore,
     {
         if let QuantifierResultItem::Address(signed_by) = decider.replace(&signed_by) {
             let message_db = SignedByDb::new(decider.get_db());
-            let messages = message_db.get_all_signed_by(*signed_by);
+            let messages = message_db.get_all_signed_by(signed_by);
             QuantifierResult::new(
                 messages
                     .iter()

--- a/ovm/src/quantifiers/signed_by_quantifier.rs
+++ b/ovm/src/quantifiers/signed_by_quantifier.rs
@@ -19,18 +19,15 @@ impl SignedByQuantifier {
     where
         KVS: KeyValueStore,
     {
-        if let QuantifierResultItem::Address(signed_by) = decider.replace(&signed_by) {
-            let message_db = SignedByDb::new(decider.get_db());
-            let messages = message_db.get_all_signed_by(signed_by);
-            QuantifierResult::new(
-                messages
-                    .iter()
-                    .map(|m| QuantifierResultItem::Bytes(m.message.clone()))
-                    .collect(),
-                true,
-            )
-        } else {
-            panic!("invalid input")
-        }
+        let signed_by = decider.replace(signed_by).to_address();
+        let message_db = SignedByDb::new(decider.get_db());
+        let messages = message_db.get_all_signed_by(signed_by);
+        QuantifierResult::new(
+            messages
+                .iter()
+                .map(|m| QuantifierResultItem::Bytes(m.message.clone()))
+                .collect(),
+            true,
+        )
     }
 }

--- a/ovm/src/statements/plasma.rs
+++ b/ovm/src/statements/plasma.rs
@@ -104,7 +104,7 @@ mod tests {
         let range = Range::new(0, 100);
         let checkpoint_property = create_plasma_property(block_number, range);
         let mut decider: PropertyExecutor<CoreDbLevelDbImpl> = Default::default();
-        store_inclusion_witness(&mut decider);
+        store_inclusion_witness(&decider);
         let result = decider.decide(&checkpoint_property);
         assert!(result.is_ok());
     }

--- a/ovm/src/statements/state_channel.rs
+++ b/ovm/src/statements/state_channel.rs
@@ -5,7 +5,7 @@ use crate::types::{
 };
 use bytes::Bytes;
 use ethereum_types::Address;
-use plasma_core::data_structure::abi::{Decodable, Encodable};
+use plasma_core::data_structure::abi::Encodable;
 
 pub fn create_state_channel_property(
     my_address: Address,

--- a/ovm/src/statements/state_channel.rs
+++ b/ovm/src/statements/state_channel.rs
@@ -1,7 +1,7 @@
 use crate::db::Message;
 use crate::types::{
-    AndDeciderInput, ForAllSuchThatInput, HasLowerNonceInput, Integer, Placeholder, Property,
-    PropertyFactory, Quantifier, QuantifierResultItem, SignedByInput,
+    AndDeciderInput, ForAllSuchThatInput, HasLowerNonceInput, InputType, Integer, Property,
+    Quantifier, SignedByInput,
 };
 use bytes::Bytes;
 use ethereum_types::Address;
@@ -14,16 +14,16 @@ pub fn create_state_channel_property(
 ) -> Property {
     let upper_nonce = Integer(latest_message.nonce.0 + 1);
     let left_property = Property::ForAllSuchThatDecider(Box::new(ForAllSuchThatInput::new(
-        Quantifier::SignedByQuantifier(Placeholder::new("my_address")),
-        Placeholder::new("message"),
+        Quantifier::SignedByQuantifier(InputType::ConstantAddress(my_address)),
+        Bytes::from("message"),
         Property::HasLowerNonceDecider(HasLowerNonceInput::new(
-            Placeholder::new("message"),
-            Placeholder::new("upper_nonce"),
+            InputType::placeholder("message"),
+            InputType::ConstantInteger(upper_nonce),
         )),
     )));
     let right_property = Property::SignedByDecider(SignedByInput::new(
-        Placeholder::new("last_message"),
-        Placeholder::new("counter_party_address"),
+        InputType::ConstantBytes(Bytes::from(latest_message.to_abi())),
+        InputType::ConstantAddress(counter_party_address),
     ));
     Property::AndDecider(Box::new(AndDeciderInput::new(
         left_property,

--- a/ovm/src/statements/state_channel.rs
+++ b/ovm/src/statements/state_channel.rs
@@ -1,7 +1,7 @@
 use crate::db::Message;
 use crate::types::{
-    AndDeciderInput, ForAllSuchThatInput, HasLowerNonceInput, Integer, Property, PropertyFactory,
-    Quantifier, QuantifierResultItem, SignedByInput,
+    AndDeciderInput, ForAllSuchThatInput, HasLowerNonceInput, Integer, Placeholder, Property,
+    PropertyFactory, Quantifier, QuantifierResultItem, SignedByInput,
 };
 use bytes::Bytes;
 use ethereum_types::Address;
@@ -14,21 +14,16 @@ pub fn create_state_channel_property(
 ) -> Property {
     let upper_nonce = Integer(latest_message.nonce.0 + 1);
     let left_property = Property::ForAllSuchThatDecider(Box::new(ForAllSuchThatInput::new(
-        Quantifier::SignedByQuantifier(my_address),
-        Some(PropertyFactory::new(Box::new(move |item| {
-            if let QuantifierResultItem::Bytes(message) = item {
-                Property::HasLowerNonceDecider(HasLowerNonceInput::new(
-                    Message::from_abi(&message).unwrap(),
-                    upper_nonce,
-                ))
-            } else {
-                panic!("invalid type in PropertyFactory");
-            }
-        }))),
+        Quantifier::SignedByQuantifier(Placeholder::new("my_address")),
+        Placeholder::new("message"),
+        Property::HasLowerNonceDecider(HasLowerNonceInput::new(
+            Placeholder::new("message"),
+            Placeholder::new("upper_nonce"),
+        )),
     )));
     let right_property = Property::SignedByDecider(SignedByInput::new(
-        Bytes::from(latest_message.to_abi()),
-        counter_party_address,
+        Placeholder::new("last_message"),
+        Placeholder::new("counter_party_address"),
     ));
     Property::AndDecider(Box::new(AndDeciderInput::new(
         left_property,

--- a/ovm/src/types.rs
+++ b/ovm/src/types.rs
@@ -4,8 +4,8 @@ pub mod inputs;
 pub mod witness;
 
 pub use self::core::{
-    Decider, Decision, ImplicationProofElement, Integer, Placeholder, Property, PropertyFactory,
-    Quantifier, QuantifierResult, QuantifierResultItem,
+    Decider, Decision, ImplicationProofElement, InputType, Integer, Property, Quantifier,
+    QuantifierResult, QuantifierResultItem,
 };
 pub use self::decision_value::DecisionValue;
 pub use self::inputs::{

--- a/ovm/src/types.rs
+++ b/ovm/src/types.rs
@@ -4,8 +4,8 @@ pub mod inputs;
 pub mod witness;
 
 pub use self::core::{
-    Decider, Decision, ImplicationProofElement, Integer, Property, PropertyFactory, Quantifier,
-    QuantifierResult, QuantifierResultItem,
+    Decider, Decision, ImplicationProofElement, Integer, Placeholder, Property, PropertyFactory,
+    Quantifier, QuantifierResult, QuantifierResultItem,
 };
 pub use self::decision_value::DecisionValue;
 pub use self::inputs::{

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -411,6 +411,44 @@ pub enum QuantifierResultItem {
     H256(H256),
 }
 
+impl QuantifierResultItem {
+    pub fn to_bytes(&self) -> Bytes {
+        if let QuantifierResultItem::Bytes(bytes) = self {
+            bytes.clone()
+        } else {
+            panic!("QuantifierResultItem isn't Bytes!")
+        }
+    }
+    pub fn to_integer(&self) -> Integer {
+        if let QuantifierResultItem::Integer(integer) = self {
+            *integer
+        } else {
+            panic!("QuantifierResultItem isn't Integer!")
+        }
+    }
+    pub fn to_address(&self) -> Address {
+        if let QuantifierResultItem::Address(address) = self {
+            *address
+        } else {
+            panic!("QuantifierResultItem isn't Address!")
+        }
+    }
+    pub fn to_h256(&self) -> H256 {
+        if let QuantifierResultItem::H256(h256) = self {
+            *h256
+        } else {
+            panic!("QuantifierResultItem isn't H256!")
+        }
+    }
+    pub fn to_range(&self) -> Range {
+        if let QuantifierResultItem::Range(range) = self {
+            *range
+        } else {
+            panic!("QuantifierResultItem isn't Range!")
+        }
+    }
+}
+
 pub struct QuantifierResult {
     results: Vec<QuantifierResultItem>,
     all_results_quantified: bool,

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -376,10 +376,10 @@ impl Decodable for InputType {
                 Ok(InputType::ConstantBytes(Bytes::from(bytes)))
             } else if id_num == 3 {
                 Ok(InputType::ConstantH256(H256::from_slice(&bytes)))
-            } else if id_num == 3 {
+            } else if id_num == 4 {
                 Ok(InputType::ConstantInteger(Bytes::from(bytes).into()))
             } else {
-                Range::from_abi(&bytes).map(|item| InputType::ConstantRange(item))
+                Range::from_abi(&bytes).map(InputType::ConstantRange)
             }
         } else {
             Err(PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))

--- a/ovm/src/types/inputs.rs
+++ b/ovm/src/types/inputs.rs
@@ -1,4 +1,4 @@
-use super::core::{Integer, Placeholder, Property, Quantifier};
+use super::core::{InputType, Integer, Property, Quantifier};
 use abi_derive::{AbiDecodable, AbiEncodable};
 use bytes::Bytes;
 use ethabi::{ParamType, Token};
@@ -55,16 +55,15 @@ impl NotDeciderInput {
     }
 }
 
-#[allow(unused_attributes)]
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct ForAllSuchThatInput {
     quantifier: Quantifier,
-    placeholder: Placeholder,
+    placeholder: Bytes,
     property: Property,
 }
 
 impl ForAllSuchThatInput {
-    pub fn new(quantifier: Quantifier, placeholder: Placeholder, property: Property) -> Self {
+    pub fn new(quantifier: Quantifier, placeholder: Bytes, property: Property) -> Self {
         ForAllSuchThatInput {
             quantifier,
             placeholder,
@@ -74,7 +73,7 @@ impl ForAllSuchThatInput {
     pub fn get_quantifier(&self) -> &Quantifier {
         &self.quantifier
     }
-    pub fn get_placeholder(&self) -> &Placeholder {
+    pub fn get_placeholder(&self) -> &Bytes {
         &self.placeholder
     }
 
@@ -85,74 +84,74 @@ impl ForAllSuchThatInput {
 
 #[derive(Clone, Debug, PartialEq, Eq, AbiDecodable, AbiEncodable)]
 pub struct PreimageExistsInput {
-    hash: Placeholder,
+    hash: InputType,
 }
 
 impl PreimageExistsInput {
-    pub fn new(hash: Placeholder) -> Self {
+    pub fn new(hash: InputType) -> Self {
         PreimageExistsInput { hash }
     }
-    pub fn get_hash(&self) -> &Placeholder {
+    pub fn get_hash(&self) -> &InputType {
         &self.hash
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct SignedByInput {
-    message: Placeholder,
-    public_key: Placeholder,
+    message: InputType,
+    public_key: InputType,
 }
 
 impl SignedByInput {
-    pub fn new(message: Placeholder, public_key: Placeholder) -> Self {
+    pub fn new(message: InputType, public_key: InputType) -> Self {
         SignedByInput {
             message,
             public_key,
         }
     }
-    pub fn get_message(&self) -> &Placeholder {
+    pub fn get_message(&self) -> &InputType {
         &self.message
     }
-    pub fn get_public_key(&self) -> &Placeholder {
+    pub fn get_public_key(&self) -> &InputType {
         &self.public_key
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct IncludedAtBlockInput {
-    block_number: Placeholder,
-    plasma_data_block: Placeholder,
+    block_number: InputType,
+    plasma_data_block: InputType,
 }
 
 impl IncludedAtBlockInput {
-    pub fn new(block_number: Placeholder, plasma_data_block: Placeholder) -> Self {
+    pub fn new(block_number: InputType, plasma_data_block: InputType) -> Self {
         Self {
             block_number,
             plasma_data_block,
         }
     }
-    pub fn get_block_number(&self) -> &Placeholder {
+    pub fn get_block_number(&self) -> &InputType {
         &self.block_number
     }
-    pub fn get_plasma_data_block(&self) -> &Placeholder {
+    pub fn get_plasma_data_block(&self) -> &InputType {
         &self.plasma_data_block
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct HasLowerNonceInput {
-    message: Placeholder,
-    nonce: Placeholder,
+    message: InputType,
+    nonce: InputType,
 }
 
 impl HasLowerNonceInput {
-    pub fn new(message: Placeholder, nonce: Placeholder) -> Self {
+    pub fn new(message: InputType, nonce: InputType) -> Self {
         HasLowerNonceInput { message, nonce }
     }
-    pub fn get_message(&self) -> &Placeholder {
+    pub fn get_message(&self) -> &InputType {
         &self.message
     }
-    pub fn get_nonce(&self) -> &Placeholder {
+    pub fn get_nonce(&self) -> &InputType {
         &self.nonce
     }
 }
@@ -176,30 +175,30 @@ impl ChannelUpdateSignatureExistsDeciderInput {
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct IntegerRangeQuantifierInput {
-    start: Placeholder,
-    end: Placeholder,
+    start: InputType,
+    end: InputType,
 }
 
 impl IntegerRangeQuantifierInput {
-    pub fn new(start: Placeholder, end: Placeholder) -> Self {
+    pub fn new(start: InputType, end: InputType) -> Self {
         Self { start, end }
     }
-    pub fn get_start(&self) -> &Placeholder {
+    pub fn get_start(&self) -> &InputType {
         &self.start
     }
-    pub fn get_end(&self) -> &Placeholder {
+    pub fn get_end(&self) -> &InputType {
         &self.end
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, AbiDecodable, AbiEncodable)]
 pub struct BlockRangeQuantifierInput {
-    pub block_number: Placeholder,
-    pub coin_range: Placeholder,
+    pub block_number: InputType,
+    pub coin_range: InputType,
 }
 
 impl BlockRangeQuantifierInput {
-    pub fn new(block_number: Placeholder, coin_range: Placeholder) -> Self {
+    pub fn new(block_number: InputType, coin_range: InputType) -> Self {
         Self {
             block_number,
             coin_range,
@@ -238,7 +237,7 @@ mod tests {
             Range::new(500, 700),
             Bytes::from(&b"root"[..]),
             true,
-            Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(Placeholder::new(
+            Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(InputType::new(
                 "hash",
             )))),
         );

--- a/ovm/src/types/inputs.rs
+++ b/ovm/src/types/inputs.rs
@@ -1,12 +1,9 @@
-use super::core::{Integer, Property, PropertyFactory, Quantifier};
-use super::witness::PlasmaDataBlock;
-use crate::db::Message;
+use super::core::{Integer, Placeholder, Property, Quantifier};
 use abi_derive::{AbiDecodable, AbiEncodable};
 use bytes::Bytes;
 use ethabi::{ParamType, Token};
-use ethereum_types::{Address, H256};
+use ethereum_types::Address;
 use plasma_core::data_structure::abi::{Decodable, Encodable};
-use plasma_core::data_structure::Range;
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct AndDeciderInput {
@@ -62,100 +59,101 @@ impl NotDeciderInput {
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct ForAllSuchThatInput {
     quantifier: Quantifier,
-    // PropertyFactory and WitnessFactory isn't serializable. Clients don't send these to smart contract directly
-    #[ignore]
-    property_factory: Option<PropertyFactory>,
+    placeholder: Placeholder,
+    property: Property,
 }
 
 impl ForAllSuchThatInput {
-    pub fn new(quantifier: Quantifier, property_factory: Option<PropertyFactory>) -> Self {
+    pub fn new(quantifier: Quantifier, placeholder: Placeholder, property: Property) -> Self {
         ForAllSuchThatInput {
             quantifier,
-            property_factory,
+            placeholder,
+            property,
         }
     }
     pub fn get_quantifier(&self) -> &Quantifier {
         &self.quantifier
     }
-    pub fn get_property_factory(&self) -> &Option<PropertyFactory> {
-        &self.property_factory
+    pub fn get_placeholder(&self) -> &Placeholder {
+        &self.placeholder
+    }
+
+    pub fn get_property(&self) -> &Property {
+        &self.property
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, AbiDecodable, AbiEncodable)]
 pub struct PreimageExistsInput {
-    hash: H256,
+    hash: Placeholder,
 }
 
 impl PreimageExistsInput {
-    pub fn new(hash: H256) -> Self {
+    pub fn new(hash: Placeholder) -> Self {
         PreimageExistsInput { hash }
     }
-    pub fn get_hash(&self) -> H256 {
-        self.hash
+    pub fn get_hash(&self) -> &Placeholder {
+        &self.hash
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct SignedByInput {
-    message: Bytes,
-    public_key: Address,
+    message: Placeholder,
+    public_key: Placeholder,
 }
 
 impl SignedByInput {
-    pub fn new(message: Bytes, public_key: Address) -> Self {
+    pub fn new(message: Placeholder, public_key: Placeholder) -> Self {
         SignedByInput {
             message,
             public_key,
         }
     }
-    pub fn get_message(&self) -> &Bytes {
+    pub fn get_message(&self) -> &Placeholder {
         &self.message
     }
-    pub fn get_public_key(&self) -> Address {
-        self.public_key
-    }
-    pub fn hash(&self) -> &Bytes {
-        &self.message
+    pub fn get_public_key(&self) -> &Placeholder {
+        &self.public_key
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct IncludedAtBlockInput {
-    block_number: Integer,
-    plasma_data_block: PlasmaDataBlock,
+    block_number: Placeholder,
+    plasma_data_block: Placeholder,
 }
 
 impl IncludedAtBlockInput {
-    pub fn new(block_number: Integer, plasma_data_block: PlasmaDataBlock) -> Self {
+    pub fn new(block_number: Placeholder, plasma_data_block: Placeholder) -> Self {
         Self {
             block_number,
             plasma_data_block,
         }
     }
-    pub fn get_block_number(&self) -> Integer {
-        self.block_number
+    pub fn get_block_number(&self) -> &Placeholder {
+        &self.block_number
     }
-    pub fn get_plasma_data_block(&self) -> &PlasmaDataBlock {
+    pub fn get_plasma_data_block(&self) -> &Placeholder {
         &self.plasma_data_block
     }
 }
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct HasLowerNonceInput {
-    message: Message,
-    nonce: Integer,
+    message: Placeholder,
+    nonce: Placeholder,
 }
 
 impl HasLowerNonceInput {
-    pub fn new(message: Message, nonce: Integer) -> Self {
+    pub fn new(message: Placeholder, nonce: Placeholder) -> Self {
         HasLowerNonceInput { message, nonce }
     }
-    pub fn get_message(&self) -> &Message {
+    pub fn get_message(&self) -> &Placeholder {
         &self.message
     }
-    pub fn get_nonce(&self) -> Integer {
-        self.nonce
+    pub fn get_nonce(&self) -> &Placeholder {
+        &self.nonce
     }
 }
 
@@ -176,16 +174,32 @@ impl ChannelUpdateSignatureExistsDeciderInput {
     }
 }
 
-pub type IntegerRangeQuantifierInput = Range;
+#[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
+pub struct IntegerRangeQuantifierInput {
+    start: Placeholder,
+    end: Placeholder,
+}
+
+impl IntegerRangeQuantifierInput {
+    pub fn new(start: Placeholder, end: Placeholder) -> Self {
+        Self { start, end }
+    }
+    pub fn get_start(&self) -> &Placeholder {
+        &self.start
+    }
+    pub fn get_end(&self) -> &Placeholder {
+        &self.end
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, AbiDecodable, AbiEncodable)]
 pub struct BlockRangeQuantifierInput {
-    pub block_number: Integer,
-    pub coin_range: Range,
+    pub block_number: Placeholder,
+    pub coin_range: Placeholder,
 }
 
 impl BlockRangeQuantifierInput {
-    pub fn new(block_number: Integer, coin_range: Range) -> Self {
+    pub fn new(block_number: Placeholder, coin_range: Placeholder) -> Self {
         Self {
             block_number,
             coin_range,
@@ -193,6 +207,7 @@ impl BlockRangeQuantifierInput {
     }
 }
 
+/*
 #[cfg(test)]
 mod tests {
 
@@ -223,7 +238,9 @@ mod tests {
             Range::new(500, 700),
             Bytes::from(&b"root"[..]),
             true,
-            Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(H256::zero()))),
+            Property::PreimageExistsDecider(Box::new(PreimageExistsInput::new(Placeholder::new(
+                "hash",
+            )))),
         );
         let input = IncludedAtBlockInput::new(Integer(10), plasma_data_block);
         let encoded = input.to_abi();
@@ -231,3 +248,4 @@ mod tests {
         assert_eq!(decoded.get_block_number(), input.get_block_number());
     }
 }
+*/

--- a/ovm/src/types/witness.rs
+++ b/ovm/src/types/witness.rs
@@ -116,6 +116,13 @@ impl Witness {
             ]
         }
     }
+    pub fn to_bytes(&self) -> &Bytes {
+        if let Witness::Bytes(bytes) = self {
+            bytes
+        } else {
+            panic!("witness isn't bytes!")
+        }
+    }
 }
 
 impl Encodable for Witness {

--- a/ovm/src/types/witness.rs
+++ b/ovm/src/types/witness.rs
@@ -78,7 +78,6 @@ impl Witness {
             if let Some(bytes) = bytes {
                 Ok(Witness::Bytes(Bytes::from(bytes)))
             } else {
-                println!("decodeing witness error");
                 Err(PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))
             }
         } else {
@@ -92,16 +91,13 @@ impl Witness {
                     PlasmaDataBlock::from_tuple(&plasma_data_block).unwrap(),
                 ))
             } else {
-                println!("decodeing witness error 1");
                 Err(PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))
             }
         }
     }
     fn from_abi_part(id: U256, data: &[u8]) -> Result<Self, PlasmaCoreError> {
-        let decoded = ethabi::decode(&Self::get_param_types(id.as_u64()), data).map_err(|_e| {
-            println!("decodeing witness error 2");
-            PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode)
-        })?;
+        let decoded = ethabi::decode(&Self::get_param_types(id.as_u64()), data)
+            .map_err(|_e| PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))?;
         Self::from_tuple_part(id.as_u64(), &decoded)
     }
     pub fn get_number(&self) -> U256 {
@@ -142,7 +138,6 @@ impl Decodable for Witness {
         if let (Some(witness_id), Some(witness_data)) = (witness_id, witness_data) {
             Ok(Witness::from_abi_part(witness_id, &witness_data).unwrap())
         } else {
-            println!("decodeing witness error");
             Err(PlasmaCoreError::from(PlasmaCoreErrorKind::AbiDecode))
         }
     }


### PR DESCRIPTION
Removing propertyFactory using template literal.  see https://github.com/plasma-group/ovm/issues/1#issuecomment-522642118

### Why did I patch client?

Claims for smart contract should be generated from property of client. Because implication proof creation needs a lot of work if properties for L1 and L2 are different.
