### PR TITLE
Add swap property #199

### DIFF
--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -53,7 +53,7 @@ impl PlasmaClientShell {
     /// Claim for ownership
     pub fn create_ownership_state_object(to_address: Address) -> Property {
         /*
-         * There exists tx such that state_update.deprecate(tx):
+         * There exists tx such that state_update.is_same_range(tx):
          *   SignedBy(tx, to_address).
          */
         DeciderManager::there_exists_such_that(vec![

--- a/ovm/src/property_executor.rs
+++ b/ovm/src/property_executor.rs
@@ -6,7 +6,7 @@ use crate::deciders::{
 use crate::error::Error;
 use crate::quantifiers::{
     BlockRangeQuantifier, HashQuantifier, IntegerRangeQuantifier,
-    NonnegativeIntegerLessThanQuantifier, SignedByQuantifier, TxQuantifier,
+    NonnegativeIntegerLessThanQuantifier, SignedByQuantifier, SwapQuantifier, TxQuantifier,
 };
 use crate::types::{
     Decider, Decision, Property, PropertyInput, QuantifierResult, QuantifierResultItem,
@@ -142,6 +142,9 @@ impl DeciderManager {
     pub fn q_tx(inputs: Vec<PropertyInput>) -> Property {
         Property::new(Self::get_decider_address(25), inputs)
     }
+    pub fn q_swap(inputs: Vec<PropertyInput>) -> Property {
+        Property::new(Self::get_decider_address(26), inputs)
+    }
 }
 
 /// Mixin for adding decide method to Property
@@ -255,6 +258,8 @@ where
             HashQuantifier::get_all_quantified(self, &property.inputs)
         } else if decider_id == DECIDER_LIST[25] {
             TxQuantifier::get_all_quantified(self, &property.inputs)
+        } else if decider_id == DECIDER_LIST[26] {
+            SwapQuantifier::get_all_quantified(self, &property.inputs)
         } else {
             panic!("unknown quantifier")
         }

--- a/ovm/src/quantifiers.rs
+++ b/ovm/src/quantifiers.rs
@@ -2,10 +2,12 @@ pub mod block_range_quantifier;
 pub mod hash_quantifier;
 pub mod integer_quantifiers;
 pub mod signed_by_quantifier;
+pub mod swap_quantifier;
 pub mod tx_quantifier;
 
 pub use self::block_range_quantifier::BlockRangeQuantifier;
 pub use self::hash_quantifier::HashQuantifier;
 pub use self::integer_quantifiers::{IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier};
 pub use self::signed_by_quantifier::SignedByQuantifier;
+pub use self::swap_quantifier::SwapQuantifier;
 pub use self::tx_quantifier::TxQuantifier;

--- a/ovm/src/quantifiers/swap_quantifier.rs
+++ b/ovm/src/quantifiers/swap_quantifier.rs
@@ -1,0 +1,109 @@
+use crate::property_executor::PropertyExecutor;
+use crate::types::{
+    Integer, Property, PropertyInput, QuantifierResult, QuantifierResultItem, StateUpdate,
+};
+use crate::DeciderManager;
+use bytes::Bytes;
+use ethereum_types::Address;
+use plasma_core::data_structure::Range;
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct SwapQuantifier {}
+
+impl Default for SwapQuantifier {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl SwapQuantifier {
+    pub fn get_all_quantified<KVS>(
+        decider: &PropertyExecutor<KVS>,
+        inputs: &[PropertyInput],
+    ) -> QuantifierResult
+    where
+        KVS: KeyValueStore,
+    {
+        let state_update = decider.get_variable(&inputs[0]).to_state_update();
+        let previous_address = decider.get_variable(&inputs[1]).to_address();
+        let next_address = decider.get_variable(&inputs[2]).to_address();
+        let token_address = decider.get_variable(&inputs[3]).to_address();
+        let corresponding_coin_range = decider.get_variable(&inputs[4]).to_range();
+        let corresponding_block_number = decider.get_variable(&inputs[5]).to_integer();
+        let corresponding_state_update = StateUpdate::new(
+            corresponding_block_number,
+            corresponding_coin_range,
+            create_swap_order_property(
+                previous_address,
+                next_address,
+                token_address,
+                state_update.get_range(),
+                state_update.get_block_number(),
+            ),
+        );
+        QuantifierResult::new(
+            vec![QuantifierResultItem::StateUpdate(
+                corresponding_state_update,
+            )],
+            true,
+        )
+    }
+}
+
+pub fn create_swap_order_property(
+    next_address: Address,
+    previous_address: Address,
+    token_address: Address,
+    corresponding_coin_range: Range,
+    corresponding_block_number: Integer,
+) -> Property {
+    /*
+     * swap(state_update, previous_owner, next_owner, corresponding_token_address, corresponding_coin_range. corresponding_block_number)
+     * := There exists tx such that state_update.is_same_range(tx):
+     *      There exists corresponding such that swap(state_update, next_owner, previous_owner, corresponding_token_address, corresponding_coin_range. corresponding_block_number):
+     *        Or(And(
+     *          SignedBy(tx, next_owner).
+     *          IsIncludedAt(corresponding)
+     *        ),And(
+     *          SignedBy(tx, previous_owner).
+     *          Not(IsIncludedAt(corresponding))
+     *        ))
+     */
+    DeciderManager::there_exists_such_that(vec![
+        PropertyInput::ConstantProperty(DeciderManager::q_tx(vec![PropertyInput::Placeholder(
+            Bytes::from("state_update"),
+        )])),
+        PropertyInput::ConstantBytes(Bytes::from("tx")),
+        PropertyInput::ConstantProperty(DeciderManager::there_exists_such_that(vec![
+            PropertyInput::ConstantProperty(DeciderManager::q_swap(vec![
+                PropertyInput::Placeholder(Bytes::from("state_update")),
+                PropertyInput::ConstantAddress(previous_address),
+                PropertyInput::ConstantAddress(next_address),
+                PropertyInput::ConstantAddress(token_address),
+                PropertyInput::ConstantRange(corresponding_coin_range),
+                PropertyInput::ConstantInteger(corresponding_block_number),
+            ])),
+            PropertyInput::ConstantBytes(Bytes::from("corresponding")),
+            PropertyInput::ConstantProperty(DeciderManager::or_decider(
+                DeciderManager::and_decider(
+                    DeciderManager::signed_by_decider(vec![
+                        PropertyInput::ConstantAddress(next_address),
+                        PropertyInput::Placeholder(Bytes::from("tx")),
+                    ]),
+                    DeciderManager::included_at_block_decider(vec![PropertyInput::Placeholder(
+                        Bytes::from("corresponding"),
+                    )]),
+                ),
+                DeciderManager::and_decider(
+                    DeciderManager::signed_by_decider(vec![
+                        PropertyInput::ConstantAddress(previous_address),
+                        PropertyInput::Placeholder(Bytes::from("tx")),
+                    ]),
+                    DeciderManager::not_decider(DeciderManager::included_at_block_decider(vec![
+                        PropertyInput::Placeholder(Bytes::from("corresponding")),
+                    ])),
+                ),
+            )),
+        ])),
+    ])
+}


### PR DESCRIPTION
I defined swap property but first version has circular reference problem because corresponding_state_update.property = is `swap(next_owner, previous_owner, state_update)`.

```
swap(previous_owner, next_owner, corresponding_state_update)
  := There exists tx such that state_update.is_same_range(tx):
            Or(And(
              SignedBy(tx, next_owner).
              IsIncludedAt(corresponding_state_update)
            ),And(
              SignedBy(tx, previous_owner).
              Not(IsIncludedAt(corresponding_state_update))
            ))
```

So I made another version, but this version still has problem. This requires application specific quantifier.

```
swap(state_update, previous_owner, next_owner, corresponding_token_address, corresponding_coin_range. corresponding_block_number)
      := There exists tx such that state_update.is_same_range(tx):
           There exists corresponding such that swap(state_update, next_owner, previous_owner, corresponding_token_address, corresponding_coin_range. corresponding_block_number):
             Or(And(
               SignedBy(tx, next_owner).
               IsIncludedAt(corresponding)
             ),And(
               SignedBy(tx, previous_owner).
               Not(IsIncludedAt(corresponding))
             ))
```