### PR TITLE
Use session instead of secret key #224

### DIFF
--- a/clients/examples/plasma_client.rs
+++ b/clients/examples/plasma_client.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use ethereum_types::Address;
 use futures::future;
 use plasma_clients::plasma::PlasmaClientShell;
@@ -6,15 +7,17 @@ fn main() {
     let commitment_contract_address_hex =
         hex::decode("9FBDa871d559710256a2502A2517b794B482Db40").unwrap();
     let commitment_contract_address = Address::from_slice(&commitment_contract_address_hex);
-    let mut shell = PlasmaClientShell::new(
-        "127.0.0.1:8080".to_string(),
-        commitment_contract_address,
-        "659cbb0e2411a44db63778987b1e22153c086a95eb6b18bdf89de078917abc63",
-    );
+    let mut shell =
+        PlasmaClientShell::new("127.0.0.1:8080".to_string(), commitment_contract_address);
     tokio::run(future::lazy(move || {
         shell.connect();
-        println!("{:?}", shell.get_balance());
-        shell.send_transaction("2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e", 0, 10);
+        println!("{:?}", shell.get_balance(&Bytes::from("")));
+        shell.send_transaction(
+            &Bytes::from(""),
+            "2932b7a2355d6fecc4b5c0b6bd44cc31df247a2e",
+            0,
+            10,
+        );
         Ok(())
     }));
 }

--- a/clients/examples/plasma_client_cli.rs
+++ b/clients/examples/plasma_client_cli.rs
@@ -30,6 +30,18 @@ fn main() {
                 .version("1.0"),
         )
         .subcommand(
+            SubCommand::with_name("import")
+                .about("import")
+                .version("1.0")
+                .arg(
+                    Arg::with_name("secret_key")
+                        .short("sk")
+                        .value_name("secret_key")
+                        .takes_value(true)
+                        .help("hex secret key"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("send")
                 .about("send money")
                 .version("1.0")
@@ -79,6 +91,13 @@ fn main() {
             shell.initialize();
             Ok(())
         }));
+    } else if matches.subcommand_matches("import").is_some() {
+        let secrey_key = value_t!(matches, "secret_key", String).unwrap();
+        tokio::run(future::lazy(move || {
+            shell.connect();
+            shell.import_account(&secrey_key);
+            Ok(())
+        }));
     } else if let Some(matches) = matches.subcommand_matches("send") {
         let to_address = value_t!(matches, "to", String).unwrap();
         let start = value_t!(matches, "start", u64).unwrap();
@@ -95,14 +114,4 @@ fn main() {
 
 fn string_to_session(session: String) -> Bytes {
     Bytes::from(hex::decode(session).unwrap())
-}
-
-fn get_private_key(account: String) -> String {
-    if account == "627306090abab3a6e1400e9345bc60c78a8bef57" {
-        "c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3".to_string()
-    } else if account == "f17f52151ebef6c7334fad080c5704d77216b732" {
-        "ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f".to_string()
-    } else {
-        "0dbbe8e4ae425a6d2687f1a7e3ba17bc98c673636790f1b8ad91193c05875ef1".to_string()
-    }
 }

--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -129,6 +129,13 @@ impl PlasmaClientShell {
         let plasma_client = controller.plasma_client.lock().unwrap();
         plasma_client.create_account()
     }
+    /// Imports secret key
+    pub fn import_account(&self, private_key: &str) -> (Bytes, SecretKey) {
+        let raw_key = hex::decode(private_key).unwrap();
+        let controller = self.controller.clone().unwrap();
+        let plasma_client = controller.plasma_client.lock().unwrap();
+        plasma_client.import_key(&raw_key)
+    }
     pub fn send_transaction(&self, session: &Bytes, to_address: &str, start: u64, end: u64) {
         let to_address = Address::from_slice(&hex::decode(to_address).unwrap());
         let controller = self.controller.clone().unwrap();
@@ -269,6 +276,11 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
     pub fn create_account(&self) -> (Bytes, SecretKey) {
         let mut wallet = WalletManager::new(self.decider.get_db());
         wallet.generate_key_session()
+    }
+
+    pub fn import_key(&self, secret_key: &[u8]) -> (Bytes, SecretKey) {
+        let mut wallet = WalletManager::new(self.decider.get_db());
+        wallet.import_key(secret_key)
     }
 
     pub fn get_my_address(&self, session: &Bytes) -> Option<Address> {

--- a/clients/src/plasma/wallet_manager.rs
+++ b/clients/src/plasma/wallet_manager.rs
@@ -27,6 +27,14 @@ impl<'a, KVS: KeyValueStore> WalletManager<'a, KVS> {
         (session, secret_key)
     }
 
+    pub fn import_key(&mut self, secret_key_raw: &[u8]) -> (Bytes, EthSecretKey) {
+        let session_raw = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+        let session = Bytes::from(session_raw);
+        let _ = self.db.put_private_key(&session, secret_key_raw); // TODO: error handling
+
+        (session, EthSecretKey::from_raw(&secret_key_raw).unwrap())
+    }
+
     pub fn get_key(&self, session: &Bytes) -> Option<EthSecretKey> {
         match self
             .db


### PR DESCRIPTION
Make plasma client can handle multiple accounts. This is temporarily way. We don't want to manage other user's private keys.

- [x] send transaction with session
- [x] get balance with session
- [x] import secret key
