### PR TITLE
Fix sending coin over ranges #216

### DIFF
--- a/clients/src/plasma/block_db.rs
+++ b/clients/src/plasma/block_db.rs
@@ -145,7 +145,7 @@ mod tests {
                 Property::new(Address::zero(), vec![]),
             )],
             vec![NewTransactionEvent::new(
-                Integer::new(0),
+                vec![Integer::new(0)],
                 Transaction::new(
                     Address::zero(),
                     Range::new(0, 5),
@@ -176,7 +176,7 @@ mod tests {
                 Property::new(Address::zero(), vec![]),
             )],
             vec![NewTransactionEvent::new(
-                Integer::new(8),
+                vec![Integer::new(8)],
                 Transaction::new(
                     Address::zero(),
                     Range::new(14, 15),

--- a/clients/src/plasma/command.rs
+++ b/clients/src/plasma/command.rs
@@ -1,9 +1,9 @@
 use super::plasma_block::PlasmaBlock;
 use abi_derive::{AbiDecodable, AbiEncodable};
-use abi_utils::Encodable;
+use abi_utils::{Encodable, Integer};
 use bytes::Bytes;
 use ethabi::{ParamType, Token};
-use ovm::types::{Integer, StateUpdateList};
+use ovm::types::StateUpdateList;
 use plasma_core::data_structure::Transaction;
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
@@ -53,6 +53,7 @@ impl FetchBlockRequest {
     }
 }
 
+/// prev_state_block_number is the block numbers which the transaction deprecated
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct NewTransactionEvent {
     pub prev_state_block_number: Integer,

--- a/clients/src/plasma/command.rs
+++ b/clients/src/plasma/command.rs
@@ -56,14 +56,14 @@ impl FetchBlockRequest {
 /// prev_state_block_number is the block numbers which the transaction deprecated
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct NewTransactionEvent {
-    pub prev_state_block_number: Integer,
+    pub prev_state_block_numbers: Vec<Integer>,
     pub transaction: Transaction,
 }
 
 impl NewTransactionEvent {
-    pub fn new(prev_state_block_number: Integer, transaction: Transaction) -> Self {
+    pub fn new(prev_state_block_numbers: Vec<Integer>, transaction: Transaction) -> Self {
         Self {
-            prev_state_block_number,
+            prev_state_block_numbers,
             transaction,
         }
     }

--- a/clients/src/plasma/plasma_aggregator.rs
+++ b/clients/src/plasma/plasma_aggregator.rs
@@ -95,11 +95,14 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaAggregator<KVS> {
             .is_ok());
         // Check that the transaction deprecate all previous state_updates within same coin range.
         for prev_state in state_updates.clone() {
+            // Current execute_state_transition returns next state_update which has the same range as transaction.
+            // It means same next_state is added to storage multiple times and it's overwrite.
             if let Ok(next_state) = prev_state.execute_state_transition(
                 &self.decider,
                 &transaction,
                 Integer(next_block_number),
             ) {
+
                 self.block_manager.enqueue_state_update(&next_state)?;
                 state_db.put_verified_state_update(&next_state)?;
             } else {

--- a/clients/src/plasma/plasma_aggregator.rs
+++ b/clients/src/plasma/plasma_aggregator.rs
@@ -102,7 +102,6 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaAggregator<KVS> {
                 &transaction,
                 Integer(next_block_number),
             ) {
-
                 self.block_manager.enqueue_state_update(&next_state)?;
                 state_db.put_verified_state_update(&next_state)?;
             } else {
@@ -206,5 +205,4 @@ mod tests {
         let result = aggregator.ingest_transaction(transaction);
         assert!(result.is_ok());
     }
-
 }

--- a/clients/src/plasma/plasma_aggregator.rs
+++ b/clients/src/plasma/plasma_aggregator.rs
@@ -80,8 +80,11 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaAggregator<KVS> {
         if state_updates.is_empty() {
             return Err(Error::from(ErrorKind::InvalidTransaction));
         }
-        let prev_state = &state_updates[0];
-        transaction_db.put_transaction(prev_state.get_block_number().0, transaction.clone());
+        // Store witness
+        // TODO: if one of these Database operation failed, need to roll back all of them.
+        for prev_state in state_updates.clone() {
+            transaction_db.put_transaction(prev_state.get_block_number().0, transaction.clone());
+        }
         let message = Bytes::from(transaction.to_body_abi());
         assert!(signed_by_db
             .store_witness(
@@ -90,33 +93,23 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaAggregator<KVS> {
                 transaction.get_signature().clone(),
             )
             .is_ok());
-
-        if !prev_state.get_range().is_subrange(&transaction.get_range()) {
-            return Err(Error::from(ErrorKind::InvalidTransaction));
+        // Check that the transaction deprecate all previous state_updates within same coin range.
+        for prev_state in state_updates.clone() {
+            if let Ok(next_state) = prev_state.execute_state_transition(
+                &self.decider,
+                &transaction,
+                Integer(next_block_number),
+            ) {
+                self.block_manager.enqueue_state_update(&next_state)?;
+                state_db.put_verified_state_update(&next_state)?;
+            } else {
+                return Err(Error::from(ErrorKind::InvalidTransaction));
+            }
         }
-        // TODO: if one of these Database operation failed, need to roll back all of them.
-        if let Ok(next_state) = prev_state.execute_state_transition(
-            &self.decider,
-            &transaction,
-            Integer(next_block_number),
-        ) {
-            let res = self.block_manager.enqueue_state_update(&next_state);
-            if res.is_err() {
-                return Err(Error::from(ErrorKind::InvalidTransaction));
-            }
-            let new_tx =
-                NewTransactionEvent::new(prev_state.get_block_number(), transaction.clone());
-            let res_tx = self.block_manager.enqueue_tx(new_tx.clone());
-            if res_tx.is_err() {
-                return Err(Error::from(ErrorKind::InvalidTransaction));
-            }
-            let res_new_state = state_db.put_verified_state_update(&next_state);
-            if res_new_state.is_err() {
-                return Err(Error::from(ErrorKind::InvalidTransaction));
-            }
-            return Ok(new_tx.clone());
-        }
-        Err(Error::from(ErrorKind::InvalidTransaction))
+        let prev_block_numbers = state_updates.iter().map(|s| s.get_block_number()).collect();
+        let new_tx = NewTransactionEvent::new(prev_block_numbers, transaction.clone());
+        self.block_manager.enqueue_tx(new_tx.clone())?;
+        Ok(new_tx)
     }
 
     pub fn submit_next_block(&mut self) -> Result<(), Error> {
@@ -185,7 +178,7 @@ mod tests {
     use ethsign::SecretKey;
     use ovm::deciders::SignVerifier;
     use plasma_core::data_structure::{Metadata, Range, Transaction, TransactionParams};
-    use plasma_db::{impls::kvs::CoreDbMemoryImpl};
+    use plasma_db::impls::kvs::CoreDbMemoryImpl;
 
     #[test]
     fn test_ingest() {

--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -402,7 +402,9 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
                 .is_ok());
         }
         for tx in block.get_transactions().iter() {
-            transaction_db.put_transaction(tx.prev_state_block_number.0, tx.transaction.clone());
+            for previous_block_number in tx.clone().prev_state_block_numbers {
+                transaction_db.put_transaction(previous_block_number.0, tx.transaction.clone());
+            }
             let message = Bytes::from(tx.transaction.to_body_abi());
             assert!(signed_by_db
                 .store_witness(
@@ -445,7 +447,9 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
         println!("handle_new_transaction");
         // println!("handle_new_transaction {:?}", event);
         let transaction_db = TransactionDb::new(self.decider.get_range_db());
-        transaction_db.put_transaction(event.prev_state_block_number.0, event.transaction.clone());
+        for previous_block_number in event.clone().prev_state_block_numbers {
+            transaction_db.put_transaction(previous_block_number.0, event.transaction.clone());
+        }
     }
 
     pub fn insert_test_ranges(&mut self) {


### PR DESCRIPTION
fixing client logic to support sending coin over multiple previous ranges which can have different block number.

I had to modify ingest_transaction, so I added spec for that before modifying.

It close #216 
