### PR TITLE
Add opening channel and atomic state property #241

### DIFF
--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -61,33 +61,6 @@ impl PlasmaClientShell {
         ])
     }
 
-    /// Claim for channel
-    pub fn create_channel_state_object(
-        my_address: Address,
-        counter_party_address: Address,
-    ) -> Property {
-        /*
-         * There exists tx such that state_update.is_same_coin_range(tx):
-         *   SignedBy(tx, to_address) and SignedBy(tx, counter_party_address)
-         */
-        DeciderManager::there_exists_such_that(vec![
-            PropertyInput::ConstantProperty(DeciderManager::q_tx(vec![
-                PropertyInput::Placeholder(Bytes::from("state_update")),
-            ])),
-            PropertyInput::ConstantBytes(Bytes::from("tx")),
-            PropertyInput::ConstantProperty(DeciderManager::and_decider(
-                DeciderManager::signed_by_decider(vec![
-                    PropertyInput::ConstantAddress(my_address),
-                    PropertyInput::Placeholder(Bytes::from("tx")),
-                ]),
-                DeciderManager::signed_by_decider(vec![
-                    PropertyInput::ConstantAddress(counter_party_address),
-                    PropertyInput::Placeholder(Bytes::from("tx")),
-                ]),
-            )),
-        ])
-    }
-
     // Claim for checkpoint
     pub fn create_checkpoint_property(specified_block_number: Integer, range: Range) -> Property {
         /*
@@ -208,10 +181,24 @@ impl PlasmaClientShell {
         &self,
         session: &Bytes,
         counter_party_address: Address,
+        block_number: Integer,
+        deposit_contract_address: Address,
+        range: Range,
     ) -> (Property, Metadata) {
         let my_address = self.get_my_address(session).unwrap();
+        let dammy_property = DeciderManager::preimage_exists_decider(vec![]);
+        let state_update = StateUpdate::new(
+            block_number,
+            deposit_contract_address,
+            range,
+            dammy_property,
+        );
         (
-            Self::create_channel_state_object(my_address, counter_party_address),
+            ovm::statements::plasma::create_channel_state_object(
+                my_address,
+                counter_party_address,
+                state_update,
+            ),
             Metadata::new(my_address, counter_party_address),
         )
     }
@@ -455,6 +442,7 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
         for s in block.get_state_updates().iter() {
             assert!(range_at_block_db
                 .store_witness(
+                    root.clone(),
                     block.get_inclusion_proof(s.clone()).unwrap(),
                     block.get_plasma_data_block(root.clone(), s.clone()),
                 )

--- a/merkle-interval-tree/src/double_layered_tree.rs
+++ b/merkle-interval-tree/src/double_layered_tree.rs
@@ -88,6 +88,9 @@ impl DoubleLayerTree {
     pub fn get_address_index(&self, address: Address) -> usize {
         self.tree.get_index(address)
     }
+    pub fn get_index(&self, address: Address, data: &Bytes) -> usize {
+        self.interval_trees.get(&address).unwrap().get_index(data)
+    }
     pub fn get_inclusion_proof(&self, address: Address, idx: usize) -> Bytes {
         let address_tree_inclusion_proof = self.tree.get_inclusion_proof(address);
         let interval_tree_inclusion_proof = self

--- a/ovm/src/db/range_at_block_db.rs
+++ b/ovm/src/db/range_at_block_db.rs
@@ -11,13 +11,15 @@ use plasma_db::RangeDbImpl;
 
 #[derive(Clone, Debug, AbiDecodable, AbiEncodable)]
 pub struct RangeAtBlockRecord {
+    pub root: Bytes,
     pub inclusion_proof: Bytes,
     pub plasma_data_block: PlasmaDataBlock,
 }
 
 impl RangeAtBlockRecord {
-    pub fn new(inclusion_proof: Bytes, plasma_data_block: PlasmaDataBlock) -> Self {
+    pub fn new(root: Bytes, inclusion_proof: Bytes, plasma_data_block: PlasmaDataBlock) -> Self {
         Self {
+            root,
             inclusion_proof,
             plasma_data_block,
         }
@@ -34,10 +36,11 @@ impl<'a, KVS: KeyValueStore> RangeAtBlockDb<'a, KVS> {
     }
     pub fn store_witness(
         &self,
+        root: Bytes,
         inclusion_proof: Bytes,
         plasma_data_block: PlasmaDataBlock,
     ) -> Result<(), Error> {
-        let record = RangeAtBlockRecord::new(inclusion_proof, plasma_data_block.clone());
+        let record = RangeAtBlockRecord::new(root, inclusion_proof, plasma_data_block.clone());
         let block_number = plasma_data_block.get_block_number();
         self.db
             .bucket(&Bytes::from(&b"range_at_block"[..]))

--- a/ovm/src/deciders/there_exists_such_that_decider.rs
+++ b/ovm/src/deciders/there_exists_such_that_decider.rs
@@ -16,7 +16,7 @@ impl ThereExistsSuchThatDecider {
             return Err(Error::from(ErrorKind::Undecided));
         }
         let mut justification = vec![ImplicationProofElement::new(
-            DeciderManager::for_all_such_that_decider_raw(inputs),
+            DeciderManager::there_exists_such_that(inputs.to_vec()),
             None,
         )];
         if true_decisions.get_outcome() {

--- a/ovm/src/property_executor.rs
+++ b/ovm/src/property_executor.rs
@@ -6,7 +6,8 @@ use crate::deciders::{
 use crate::error::Error;
 use crate::quantifiers::{
     BlockRangeQuantifier, HashQuantifier, IntegerRangeQuantifier,
-    NonnegativeIntegerLessThanQuantifier, SignedByQuantifier, TxQuantifier,
+    NonnegativeIntegerLessThanQuantifier, PropertyQuantifier, SignedByQuantifier,
+    StateUpdateQuantifier, TxQuantifier,
 };
 use crate::types::{
     Decider, Decision, Property, PropertyInput, QuantifierResult, QuantifierResultItem,
@@ -142,6 +143,12 @@ impl DeciderManager {
     pub fn q_tx(inputs: Vec<PropertyInput>) -> Property {
         Property::new(Self::get_decider_address(25), inputs)
     }
+    pub fn q_property(inputs: Vec<PropertyInput>) -> Property {
+        Property::new(Self::get_decider_address(26), inputs)
+    }
+    pub fn q_state_update(inputs: Vec<PropertyInput>) -> Property {
+        Property::new(Self::get_decider_address(27), inputs)
+    }
 }
 
 /// Mixin for adding decide method to Property
@@ -208,6 +215,9 @@ where
             PropertyInput::ConstantProperty(constant) => {
                 QuantifierResultItem::Property(constant.clone())
             }
+            PropertyInput::ConstantStateUpdate(constant) => {
+                QuantifierResultItem::StateUpdate(constant.clone())
+            }
             PropertyInput::ConstantMessage(constant) => {
                 QuantifierResultItem::Message(constant.clone())
             }
@@ -255,6 +265,10 @@ where
             HashQuantifier::get_all_quantified(self, &property.inputs)
         } else if decider_id == DECIDER_LIST[25] {
             TxQuantifier::get_all_quantified(self, &property.inputs)
+        } else if decider_id == DECIDER_LIST[26] {
+            PropertyQuantifier::get_all_quantified(self, &property.inputs)
+        } else if decider_id == DECIDER_LIST[27] {
+            StateUpdateQuantifier::get_all_quantified(self, &property.inputs)
         } else {
             panic!("unknown quantifier")
         }

--- a/ovm/src/quantifiers.rs
+++ b/ovm/src/quantifiers.rs
@@ -1,11 +1,15 @@
 pub mod block_range_quantifier;
 pub mod hash_quantifier;
 pub mod integer_quantifiers;
+pub mod property_quantifier;
 pub mod signed_by_quantifier;
+pub mod state_update_quantifier;
 pub mod tx_quantifier;
 
 pub use self::block_range_quantifier::BlockRangeQuantifier;
 pub use self::hash_quantifier::HashQuantifier;
 pub use self::integer_quantifiers::{IntegerRangeQuantifier, NonnegativeIntegerLessThanQuantifier};
+pub use self::property_quantifier::PropertyQuantifier;
 pub use self::signed_by_quantifier::SignedByQuantifier;
+pub use self::state_update_quantifier::StateUpdateQuantifier;
 pub use self::tx_quantifier::TxQuantifier;

--- a/ovm/src/quantifiers/property_quantifier.rs
+++ b/ovm/src/quantifiers/property_quantifier.rs
@@ -1,0 +1,26 @@
+use crate::property_executor::PropertyExecutor;
+use crate::statements::plasma::*;
+use crate::types::{Property, PropertyInput, QuantifierResult, QuantifierResultItem};
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct PropertyQuantifier {}
+
+impl Default for PropertyQuantifier {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl PropertyQuantifier {
+    pub fn get_all_quantified<KVS>(
+        decider: &PropertyExecutor<KVS>,
+        inputs: &[PropertyInput],
+    ) -> QuantifierResult
+    where
+        KVS: KeyValueStore,
+    {
+        // TODO: switch by property factory address
+        let property: Property = create_channel_state_object_for_variables(decider, inputs);
+        QuantifierResult::new(vec![QuantifierResultItem::Property(property)], true)
+    }
+}

--- a/ovm/src/quantifiers/property_quantifier.rs
+++ b/ovm/src/quantifiers/property_quantifier.rs
@@ -3,6 +3,7 @@ use crate::statements::plasma::*;
 use crate::types::{Property, PropertyInput, QuantifierResult, QuantifierResultItem};
 use plasma_db::traits::kvs::KeyValueStore;
 
+/// PropertyQuantifier is quantifier which calls Property Factory.
 pub struct PropertyQuantifier {}
 
 impl Default for PropertyQuantifier {
@@ -19,6 +20,8 @@ impl PropertyQuantifier {
     where
         KVS: KeyValueStore,
     {
+        // In smart contract side, quantifier should call Property Factory contract.println!
+        // So, First item of inputs should be address of Property Factpry contract.
         // TODO: switch by property factory address
         let property: Property = create_channel_state_object_for_variables(decider, inputs);
         QuantifierResult::new(vec![QuantifierResultItem::Property(property)], true)

--- a/ovm/src/quantifiers/state_update_quantifier.rs
+++ b/ovm/src/quantifiers/state_update_quantifier.rs
@@ -2,6 +2,7 @@ use crate::property_executor::PropertyExecutor;
 use crate::types::{PropertyInput, QuantifierResult, QuantifierResultItem, StateUpdate};
 use plasma_db::traits::kvs::KeyValueStore;
 
+/// StateUpdateQuantifier is quantifier which returns StateUpdate.
 pub struct StateUpdateQuantifier {}
 
 impl Default for StateUpdateQuantifier {

--- a/ovm/src/quantifiers/state_update_quantifier.rs
+++ b/ovm/src/quantifiers/state_update_quantifier.rs
@@ -1,0 +1,29 @@
+use crate::property_executor::PropertyExecutor;
+use crate::types::{PropertyInput, QuantifierResult, QuantifierResultItem, StateUpdate};
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub struct StateUpdateQuantifier {}
+
+impl Default for StateUpdateQuantifier {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+impl StateUpdateQuantifier {
+    pub fn get_all_quantified<KVS>(
+        decider: &PropertyExecutor<KVS>,
+        inputs: &[PropertyInput],
+    ) -> QuantifierResult
+    where
+        KVS: KeyValueStore,
+    {
+        let block_number = decider.get_variable(&inputs[0]).to_integer();
+        let deposit_contract_address = decider.get_variable(&inputs[1]).to_address();
+        let coin_range = decider.get_variable(&inputs[2]).to_range();
+        let property = decider.get_variable(&inputs[3]).to_property();
+        let state_update =
+            StateUpdate::new(block_number, deposit_contract_address, coin_range, property);
+        QuantifierResult::new(vec![QuantifierResultItem::StateUpdate(state_update)], true)
+    }
+}

--- a/ovm/src/statements/plasma.rs
+++ b/ovm/src/statements/plasma.rs
@@ -1,6 +1,11 @@
+pub mod atomic_state;
+pub mod channel;
+
 use crate::types::{Integer, Property, PropertyInput};
 use crate::DeciderManager;
+pub use atomic_state::*;
 use bytes::Bytes;
+pub use channel::*;
 use plasma_core::data_structure::Range;
 
 /// Creates plasma checkpoint property
@@ -101,7 +106,7 @@ mod tests {
             leaves[0].data.clone(),
         );
         assert!(db
-            .store_witness(inclusion_proof, plasma_data_block.clone())
+            .store_witness(root, inclusion_proof, plasma_data_block.clone())
             .is_ok());
 
         let tx_body =

--- a/ovm/src/statements/plasma/atomic_state.rs
+++ b/ovm/src/statements/plasma/atomic_state.rs
@@ -1,0 +1,54 @@
+use crate::types::{Property, PropertyInput};
+use crate::DeciderManager;
+use abi_utils::Integer;
+use bytes::Bytes;
+use ethereum_types::Address;
+use plasma_core::data_structure::Range;
+
+pub fn create_atomic_state(
+    block_number: Integer,
+    deposit_contract_address: Address,
+    coin_range: Range,
+    corresponding_inputs: Vec<PropertyInput>,
+    property1: Property,
+    property2: Property,
+) -> Property {
+    /*
+     * There exists corresponding_property = create_channel(counter_party_address, my_address):
+     *   There exists correspondent such that correspondent = create_state_update(corresponding_range, corresponding_property):
+     *     Or(
+     *       And(IncludedAt(correspondent), property1),
+     *       And(Not(IncludedAt(correspondent)), property2)
+     *     )
+     *
+     */
+    DeciderManager::there_exists_such_that(vec![
+        PropertyInput::ConstantProperty(DeciderManager::q_property(corresponding_inputs)),
+        PropertyInput::ConstantBytes(Bytes::from("property")),
+        PropertyInput::ConstantProperty(DeciderManager::there_exists_such_that(vec![
+            PropertyInput::ConstantProperty(DeciderManager::q_state_update(vec![
+                PropertyInput::ConstantInteger(block_number),
+                PropertyInput::ConstantAddress(deposit_contract_address),
+                PropertyInput::ConstantRange(coin_range),
+                PropertyInput::Placeholder(Bytes::from("property")),
+            ])),
+            PropertyInput::ConstantBytes(Bytes::from("state_update")),
+            PropertyInput::ConstantProperty(DeciderManager::or_decider(
+                DeciderManager::and_decider(
+                    DeciderManager::included_at_block_decider(vec![
+                        PropertyInput::ConstantInteger(block_number),
+                        PropertyInput::Placeholder(Bytes::from("state_update")),
+                    ]),
+                    property1,
+                ),
+                DeciderManager::and_decider(
+                    DeciderManager::not_decider(DeciderManager::included_at_block_decider(vec![
+                        PropertyInput::ConstantInteger(block_number),
+                        PropertyInput::Placeholder(Bytes::from("state_update")),
+                    ])),
+                    property2,
+                ),
+            )),
+        ])),
+    ])
+}

--- a/ovm/src/statements/plasma/channel.rs
+++ b/ovm/src/statements/plasma/channel.rs
@@ -195,7 +195,6 @@ mod tests {
             end: 200,
             data: Bytes::from(corresponding_state_update.to_abi()),
         };
-        println!("leaf3 = {:?}", hex::encode(leaf3.clone().data));
         let tree = DoubleLayerTree::generate(&[leaf1, leaf2, leaf3.clone()]);
         let root = tree.get_root();
         let index = tree.get_index(corresponding_deposit_contract_address, &leaf3.data);
@@ -221,7 +220,6 @@ mod tests {
             QuantifierResultItem::StateUpdate(state_update),
         );
         let result = decider.decide(&property);
-        println!("{:?}", result);
         assert!(result.is_ok());
         assert!(result.ok().unwrap().get_outcome());
     }

--- a/ovm/src/statements/plasma/channel.rs
+++ b/ovm/src/statements/plasma/channel.rs
@@ -85,16 +85,44 @@ mod tests {
     use crate::db::{RangeAtBlockDb, SignedByDb, TransactionDb};
     use crate::deciders::signed_by_decider::Verifier as SignatureVerifier;
     use crate::property_executor::PropertyExecutor;
-    use crate::types::{PlasmaDataBlock, QuantifierResultItem, StateUpdate};
+    use crate::types::{PlasmaDataBlock, Property, QuantifierResultItem, StateUpdate};
     use crate::DeciderManager;
     use abi_utils::abi::Encodable;
     use abi_utils::Integer;
     use bytes::Bytes;
-    use ethereum_types::Address;
+    use ethereum_types::{Address, H256};
     use ethsign::SecretKey;
     use merkle_interval_tree::{DoubleLayerTree, DoubleLayerTreeLeaf};
     use plasma_core::data_structure::{Metadata, Range, Transaction, TransactionParams};
     use plasma_db::impls::kvs::CoreDbMemoryImpl;
+
+    fn make_state_update(
+        block_number: Integer,
+        deposit_contract_address: Address,
+        range: Range,
+        corresponding_deposit_contract_address: Address,
+        corresponding_range: Range,
+        alice: Address,
+        bob: Address,
+    ) -> (Property, StateUpdate) {
+        let dammy_property = DeciderManager::preimage_exists_decider(vec![]);
+        let corresponding_state_update = StateUpdate::new(
+            block_number,
+            corresponding_deposit_contract_address,
+            corresponding_range,
+            dammy_property,
+        );
+        let property = create_channel_state_object(alice, bob, corresponding_state_update.clone());
+        (
+            property.clone(),
+            StateUpdate::new(
+                block_number,
+                deposit_contract_address,
+                range,
+                property.clone(),
+            ),
+        )
+    }
 
     #[test]
     fn test_succeed_to_decide_channel() {
@@ -114,21 +142,24 @@ mod tests {
         let corresponding_deposit_contract_address = Address::random();
         let corresponding_range = Range::new(100, 200);
 
-        let dammy_property = DeciderManager::preimage_exists_decider(vec![]);
-        let corresponding_state_update = StateUpdate::new(
-            block_number,
-            corresponding_deposit_contract_address,
-            corresponding_range,
-            dammy_property,
-        );
-        let property = create_channel_state_object(alice, bob, corresponding_state_update.clone());
-        let state_update = StateUpdate::new(
+        let (property, state_update) = make_state_update(
             block_number,
             deposit_contract_address,
             range,
-            property.clone(),
+            corresponding_deposit_contract_address,
+            corresponding_range,
+            alice,
+            bob,
         );
-
+        let (_, corresponding_state_update) = make_state_update(
+            block_number,
+            corresponding_deposit_contract_address,
+            corresponding_range,
+            deposit_contract_address,
+            range,
+            bob,
+            alice,
+        );
         let decider: PropertyExecutor<CoreDbMemoryImpl> = Default::default();
         let tx_db = TransactionDb::new(decider.get_range_db());
         let signed_by_db = SignedByDb::new(decider.get_db());
@@ -156,19 +187,30 @@ mod tests {
         };
         let leaf2 = DoubleLayerTreeLeaf {
             address: corresponding_deposit_contract_address,
+            end: 100,
+            data: Bytes::from(H256::zero().as_bytes()),
+        };
+        let leaf3 = DoubleLayerTreeLeaf {
+            address: corresponding_deposit_contract_address,
             end: 200,
             data: Bytes::from(corresponding_state_update.to_abi()),
         };
-        let tree = DoubleLayerTree::generate(&[leaf1, leaf2.clone()]);
+        println!("leaf3 = {:?}", hex::encode(leaf3.clone().data));
+        let tree = DoubleLayerTree::generate(&[leaf1, leaf2, leaf3.clone()]);
         let root = tree.get_root();
-        let inclusion_proof = tree.get_inclusion_proof(corresponding_deposit_contract_address, 0);
+        let index = tree.get_index(corresponding_deposit_contract_address, &leaf3.data);
+        let inclusion_proof =
+            tree.get_inclusion_proof(corresponding_deposit_contract_address, index);
+        let inclusion_bounds_result =
+            DoubleLayerTree::verify(&leaf3, inclusion_proof.clone(), &root);
+        assert!(inclusion_bounds_result);
         let plasma_data_block = PlasmaDataBlock::new(
             corresponding_deposit_contract_address,
             Range::new(100, 200),
             root.clone(),
             true,
             block_number,
-            leaf2.data.clone(),
+            leaf3.data.clone(),
         );
         assert!(range_at_block_db
             .store_witness(root, inclusion_proof, plasma_data_block.clone())

--- a/ovm/src/statements/plasma/channel.rs
+++ b/ovm/src/statements/plasma/channel.rs
@@ -1,0 +1,186 @@
+use super::atomic_state::create_atomic_state;
+use crate::property_executor::PropertyExecutor;
+use crate::types::{Property, PropertyInput, StateUpdate};
+use crate::DeciderManager;
+use bytes::Bytes;
+use ethereum_types::Address;
+use plasma_db::traits::kvs::KeyValueStore;
+
+pub fn create_channel_state_object_for_variables<KVS: KeyValueStore>(
+    decider: &PropertyExecutor<KVS>,
+    inputs: &[PropertyInput],
+) -> Property {
+    let my_address = decider.get_variable(&inputs[0]).to_address();
+    let counter_party_address = decider.get_variable(&inputs[1]).to_address();
+    let corresponding_state_update = decider.get_variable(&inputs[2]).to_state_update();
+    create_channel_state_object(
+        my_address,
+        counter_party_address,
+        corresponding_state_update,
+    )
+}
+
+/// channel property for Plasma
+pub fn create_channel_state_object(
+    my_address: Address,
+    counter_party_address: Address,
+    corresponding_state_update: StateUpdate,
+) -> Property {
+    /*
+     * There exists tx such that state_update.is_same_coin_range(tx):
+     *   There exists corresponding_property = create_channel(counter_party_address, my_address):
+     *     There exists correspondent such that correspondent = create_state_update(corresponding_range, corresponding_property):
+     *       Or(
+     *         And(IncludedAt(correspondent), SignedBy(tx, to_address), SignedBy(tx, counter_party_address)),
+     *         And(Not(IncludedAt(correspondent)), SignedBy(tx, counter_party_address))
+     *       )
+     *
+     * This can be compiled to small property.
+     *
+     * There exists tx such that state_update.is_same_coin_range(tx):
+     *   AtomicStateUpdate(
+     *     create_channel(counter_party_address, my_address),
+     *     corresponding_range,
+     *     And(SignedBy(tx, to_address), SignedBy(tx, counter_party_address)),
+     *     SignedBy(tx, counter_party_address)
+     *   )
+     *
+     */
+    DeciderManager::there_exists_such_that(vec![
+        PropertyInput::ConstantProperty(DeciderManager::q_tx(vec![PropertyInput::Placeholder(
+            Bytes::from("state_update"),
+        )])),
+        PropertyInput::ConstantBytes(Bytes::from("tx")),
+        PropertyInput::ConstantProperty(create_atomic_state(
+            corresponding_state_update.get_block_number(),
+            corresponding_state_update.get_deposit_contract_address(),
+            corresponding_state_update.get_range(),
+            vec![
+                PropertyInput::ConstantAddress(counter_party_address),
+                PropertyInput::ConstantAddress(my_address),
+                PropertyInput::Placeholder(Bytes::from("state_update")),
+            ],
+            DeciderManager::and_decider(
+                DeciderManager::signed_by_decider(vec![
+                    PropertyInput::ConstantAddress(my_address),
+                    PropertyInput::Placeholder(Bytes::from("tx")),
+                ]),
+                DeciderManager::signed_by_decider(vec![
+                    PropertyInput::ConstantAddress(counter_party_address),
+                    PropertyInput::Placeholder(Bytes::from("tx")),
+                ]),
+            ),
+            DeciderManager::signed_by_decider(vec![
+                PropertyInput::ConstantAddress(my_address),
+                PropertyInput::Placeholder(Bytes::from("tx")),
+            ]),
+        )),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::create_channel_state_object;
+    use crate::db::{RangeAtBlockDb, SignedByDb, TransactionDb};
+    use crate::deciders::signed_by_decider::Verifier as SignatureVerifier;
+    use crate::property_executor::PropertyExecutor;
+    use crate::types::{PlasmaDataBlock, QuantifierResultItem, StateUpdate};
+    use crate::DeciderManager;
+    use abi_utils::abi::Encodable;
+    use abi_utils::Integer;
+    use bytes::Bytes;
+    use ethereum_types::Address;
+    use ethsign::SecretKey;
+    use merkle_interval_tree::{DoubleLayerTree, DoubleLayerTreeLeaf};
+    use plasma_core::data_structure::{Metadata, Range, Transaction, TransactionParams};
+    use plasma_db::impls::kvs::CoreDbMemoryImpl;
+
+    #[test]
+    fn test_succeed_to_decide_channel() {
+        let raw_key_alice =
+            hex::decode("c87509a1c067bbde78beb793e6fa76530b6382a4c0241e5e4a9ec0a0f44dc0d3")
+                .unwrap();
+        let raw_key_bob =
+            hex::decode("ae6ae8e5ccbfb04590405997ee2d52d2b330726137b875053c36d94e974d162f")
+                .unwrap();
+        let secret_key = SecretKey::from_raw(&raw_key_alice).unwrap();
+        let secret_key_bob = SecretKey::from_raw(&raw_key_bob).unwrap();
+        let alice: Address = secret_key.public().address().into();
+        let bob = secret_key_bob.public().address().into();
+        let block_number = Integer(10);
+        let deposit_contract_address = Address::random();
+        let range = Range::new(0, 100);
+        let corresponding_deposit_contract_address = Address::random();
+        let corresponding_range = Range::new(100, 200);
+
+        let dammy_property = DeciderManager::preimage_exists_decider(vec![]);
+        let corresponding_state_update = StateUpdate::new(
+            block_number,
+            corresponding_deposit_contract_address,
+            corresponding_range,
+            dammy_property,
+        );
+        let property = create_channel_state_object(alice, bob, corresponding_state_update.clone());
+        let state_update = StateUpdate::new(
+            block_number,
+            deposit_contract_address,
+            range,
+            property.clone(),
+        );
+
+        let decider: PropertyExecutor<CoreDbMemoryImpl> = Default::default();
+        let tx_db = TransactionDb::new(decider.get_range_db());
+        let signed_by_db = SignedByDb::new(decider.get_db());
+        let range_at_block_db = RangeAtBlockDb::new(decider.get_range_db());
+        let tx_params =
+            TransactionParams::new(Address::zero(), Range::new(0, 100), Bytes::default());
+        let tx_body = Bytes::from(tx_params.to_abi());
+        let signature = SignatureVerifier::sign(&secret_key, &tx_body);
+        let signature_bob = SignatureVerifier::sign(&secret_key_bob, &tx_body);
+        tx_db.put_transaction(
+            state_update.get_block_number().0,
+            Transaction::from_params(tx_params, signature.clone(), Metadata::default()),
+        );
+        assert!(signed_by_db
+            .store_witness(alice, tx_body.clone(), signature.clone())
+            .is_ok());
+        assert!(signed_by_db
+            .store_witness(bob, tx_body.clone(), signature_bob.clone())
+            .is_ok());
+
+        let leaf1 = DoubleLayerTreeLeaf {
+            address: deposit_contract_address,
+            end: 100,
+            data: Bytes::from(state_update.to_abi()),
+        };
+        let leaf2 = DoubleLayerTreeLeaf {
+            address: corresponding_deposit_contract_address,
+            end: 200,
+            data: Bytes::from(corresponding_state_update.to_abi()),
+        };
+        let tree = DoubleLayerTree::generate(&[leaf1, leaf2.clone()]);
+        let root = tree.get_root();
+        let inclusion_proof = tree.get_inclusion_proof(corresponding_deposit_contract_address, 0);
+        let plasma_data_block = PlasmaDataBlock::new(
+            corresponding_deposit_contract_address,
+            Range::new(100, 200),
+            root.clone(),
+            true,
+            block_number,
+            leaf2.data.clone(),
+        );
+        assert!(range_at_block_db
+            .store_witness(root, inclusion_proof, plasma_data_block.clone())
+            .is_ok());
+
+        decider.set_variable(
+            Bytes::from("state_update"),
+            QuantifierResultItem::StateUpdate(state_update),
+        );
+        let result = decider.decide(&property);
+        println!("{:?}", result);
+        assert!(result.is_ok());
+        assert!(result.ok().unwrap().get_outcome());
+    }
+}

--- a/ovm/src/types/state_update.rs
+++ b/ovm/src/types/state_update.rs
@@ -15,7 +15,7 @@ use plasma_core::data_structure::{Range, Transaction};
 use plasma_db::traits::kvs::KeyValueStore;
 use tiny_keccak::Keccak;
 
-#[derive(Clone, Debug, AbiEncodable, AbiDecodable)]
+#[derive(Clone, Debug, PartialEq, Eq, AbiEncodable, AbiDecodable)]
 pub struct StateUpdate {
     block_number: Integer,
     deposit_contract_address: Address,


### PR DESCRIPTION
I found secure opening channel and atomic swap are almost same property.
And both require atomic state_update construction which is described [here](https://plasma.build/t/architecture-design-idea-of-atomic-swap-predicate/124/3).
So I add atomic_state property factory as standard library.