### PR TITLE
Property type, RangeDb Update, Fix StateDb put_verified_state_update

### DIFF
--- a/clients/examples/plasma_client_server.rs
+++ b/clients/examples/plasma_client_server.rs
@@ -354,7 +354,10 @@ fn create_exchange_offer(
     plasma_client: web::Data<PlasmaClientShell>,
 ) -> Result<HttpResponse> {
     let session = decode_session(body.session.clone()).unwrap();
-    if let Some(range) = plasma_client.search_range(body.offer.token_address, body.offer.amount) {
+    let account = plasma_client.get_my_address(&session).unwrap();
+    if let Some(range) =
+        plasma_client.search_range(body.offer.token_address, body.offer.amount, account)
+    {
         let (property, metadata) = plasma_client.making_order_property(
             &session,
             body.offer.counter_party.token_address,

--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -128,11 +128,16 @@ impl PlasmaClientShell {
         );
         tokio::spawn(watcher);
     }
-    pub fn search_range(&self, deposit_contract_address: Address, amount: u64) -> Option<Range> {
+    pub fn search_range(
+        &self,
+        deposit_contract_address: Address,
+        amount: u64,
+        owner: Address,
+    ) -> Option<Range> {
         self.controller
             .clone()
             .unwrap()
-            .search_range(deposit_contract_address, amount)
+            .search_range(deposit_contract_address, amount, owner)
     }
     /// Creates new account
     pub fn create_account(&self) -> (Bytes, SecretKey) {
@@ -316,11 +321,16 @@ impl PlasmaClientController {
         let mut plasma_client = self.plasma_client.lock().unwrap();
         plasma_client.insert_test_ranges()
     }
-    fn search_range(&self, deposit_contract_address: Address, amount: u64) -> Option<Range> {
+    fn search_range(
+        &self,
+        deposit_contract_address: Address,
+        amount: u64,
+        owner: Address,
+    ) -> Option<Range> {
         self.plasma_client
             .lock()
             .unwrap()
-            .search_range(deposit_contract_address, amount)
+            .search_range(deposit_contract_address, amount, owner)
     }
     fn get_related_transactions(&self, session: &Bytes) -> Vec<Transaction> {
         self.plasma_client
@@ -595,10 +605,17 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
     }
 
     /// return range if enough amount is exists.
-    pub fn search_range(&self, deposit_contract_address: Address, amount: u64) -> Option<Range> {
+    pub fn search_range(
+        &self,
+        deposit_contract_address: Address,
+        amount: u64,
+        owner: Address,
+    ) -> Option<Range> {
         // TODO: decide if this property is owner's property.
         self.get_state_updates(deposit_contract_address)
             .iter()
+            .filter(|su| su.is_ownership_state())
+            .filter(|su| su.get_owner() == owner)
             .map(|su| su.get_range())
             .find(|range| amount <= range.get_end() - range.get_start())
     }

--- a/clients/src/plasma/plasma_client.rs
+++ b/clients/src/plasma/plasma_client.rs
@@ -631,7 +631,7 @@ impl<KVS: KeyValueStore + DatabaseTrait> PlasmaClient<KVS> {
             .address_from(address)
             .block_from(0)
             .block_to(latest_block_number)
-            .range(Range::new(0, 1000)) // TODO: max range?
+            .range(Range::new(0, 10000))
             .build();
 
         transaction_db.query_transaction(filter).unwrap()

--- a/db/src/impls/rangedb.rs
+++ b/db/src/impls/rangedb.rs
@@ -236,14 +236,14 @@ mod tests {
         let base_db = CoreDbMemoryImpl::open("test");
         let db = RangeDbImpl::from(base_db);
         let _ = db.put(0, 100, b"Alice is owner");
-        let _ = db.put(0, 20, b"Bob is owner");
+        let _ = db.put(0, 50, b"Bob is owner");
 
         let result = db.get(0, 100).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].get_start(), 0);
-        assert_eq!(result[0].get_end(), 20);
+        assert_eq!(result[0].get_end(), 50);
         assert_eq!(result[0].get_value(), b"Bob is owner");
-        assert_eq!(result[1].get_start(), 20);
+        assert_eq!(result[1].get_start(), 50);
         assert_eq!(result[1].get_end(), 100);
         assert_eq!(result[1].get_value(), b"Alice is owner");
     }

--- a/db/src/impls/rangedb.rs
+++ b/db/src/impls/rangedb.rs
@@ -123,6 +123,21 @@ where
             Err(Error::from(ErrorKind::Dammy))
         }
     }
+    fn update(&self, start: u64, end: u64, f: Box<dyn Fn(Range) -> Vec<u8>>) -> Result<(), Error> {
+        let input_ranges = self.del_batch(start, end)?;
+        if !Self::validate_range(start, end) {
+            return Err(Error::from(ErrorKind::Dammy));
+        }
+        let output_ranges: Vec<Range> = input_ranges
+            .iter()
+            .map(|range| Range::new(range.get_start(), range.get_end(), &f(range.clone())))
+            .collect();
+        if self.put_batch(&output_ranges).is_ok() {
+            Ok(())
+        } else {
+            Err(Error::from(ErrorKind::Dammy))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -293,5 +308,30 @@ mod tests {
         assert_eq!(result[0].get_start(), 0);
         assert_eq!(result[0].get_end(), 50);
         assert_eq!(result[0].get_value(), b"Bob is owner");
+    }
+
+    #[test]
+    fn test_update() {
+        let base_db = CoreDbMemoryImpl::open("test");
+        let db = RangeDbImpl::from(base_db);
+        let _ = db.put(0, 10, b"010");
+        let _ = db.put(10, 20, b"1020");
+        let _ = db.put(20, 30, b"2030");
+        let _ = db.update(
+            0,
+            20,
+            Box::new(|_r| Bytes::from(format!("{}{}", 0, 0)).to_vec()),
+        );
+        let result = db.get(0, 30).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].get_start(), 0);
+        assert_eq!(result[0].get_end(), 10);
+        assert_eq!(result[0].get_value(), b"00");
+        assert_eq!(result[1].get_start(), 10);
+        assert_eq!(result[1].get_end(), 20);
+        assert_eq!(result[1].get_value(), b"00");
+        assert_eq!(result[2].get_start(), 20);
+        assert_eq!(result[2].get_end(), 30);
+        assert_eq!(result[2].get_value(), b"2030");
     }
 }

--- a/db/src/prelude.rs
+++ b/db/src/prelude.rs
@@ -1,6 +1,8 @@
 pub use super::error::{Error as PlasmaDbError, ErrorKind as PlasmaDbErrorKind};
+#[cfg(feature = "require-leveldb")]
+pub use super::impls::kvs::CoreDbLevelDbImpl;
 pub use super::impls::{
-    kvs::{CoreDbLevelDbImpl, CoreDbMemoryImpl, GlobalMemoryDb},
+    kvs::{CoreDbMemoryImpl, GlobalMemoryDb},
     rangedb::RangeDbImpl,
 };
 pub use super::traits::{

--- a/db/src/traits/rangestore.rs
+++ b/db/src/traits/rangestore.rs
@@ -8,4 +8,6 @@ pub trait RangeStore {
     fn del(&self, start: u64, end: u64) -> Result<Box<[Range]>, Error>;
     /// put a range in start and end
     fn put(&self, start: u64, end: u64, value: &[u8]) -> Result<(), Error>;
+    /// update ranges between start and end applying closure
+    fn update(&self, start: u64, end: u64, f: Box<dyn Fn(Range) -> Vec<u8>>) -> Result<(), Error>;
 }

--- a/ovm/src/property_executor.rs
+++ b/ovm/src/property_executor.rs
@@ -23,7 +23,7 @@ fn get_address(address: &str) -> Address {
 }
 
 lazy_static! {
-    static ref DECIDER_LIST: Vec<Address> = {
+    pub static ref DECIDER_LIST: Vec<Address> = {
         let mut list = vec![];
         list.push(get_address("722d70e765d4ec72719d29fcbefe595480a9a3a0"));
         list.push(get_address("0888415d7a6b971d6fdb15d62d795f2a909d8065"));

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -10,7 +10,6 @@ use ethabi::{ParamType, Token};
 use ethereum_types::{Address, H256};
 use plasma_core::data_structure::Range;
 use plasma_db::traits::kvs::KeyValueStore;
-use tiny_keccak::Keccak;
 
 pub type DeciderId = Address;
 pub type QuantifierId = Address;

--- a/ovm/src/types/core.rs
+++ b/ovm/src/types/core.rs
@@ -1,7 +1,7 @@
 use super::state_update::StateUpdate;
 use crate::db::Message;
 use crate::error::Error;
-use crate::property_executor::PropertyExecutor;
+use crate::property_executor::{PropertyExecutor, DECIDER_LIST};
 use crate::types::PropertyInput;
 pub use abi_utils::Integer;
 use abi_utils::{Decodable, Encodable, Error as AbiError, ErrorKind as AbiErrorKind};
@@ -10,6 +10,7 @@ use ethabi::{ParamType, Token};
 use ethereum_types::{Address, H256};
 use plasma_core::data_structure::Range;
 use plasma_db::traits::kvs::KeyValueStore;
+use tiny_keccak::Keccak;
 
 pub type DeciderId = Address;
 pub type QuantifierId = Address;
@@ -25,6 +26,59 @@ pub struct Property {
 impl Property {
     pub fn new(decider: Address, inputs: Vec<PropertyInput>) -> Self {
         Self { decider, inputs }
+    }
+
+    pub fn get_type_string(&self) -> String {
+        let inputs_str: Vec<String> = self.inputs.iter().map(|i| i.get_type_string()).collect();
+        format!("{}({})", self.get_decider_name(), inputs_str.join(","))
+    }
+
+    // TODO: use macro
+    fn get_decider_name(&self) -> String {
+        let decider = self.decider;
+        if decider == DECIDER_LIST[0] {
+            "and".to_string()
+        } else if decider == DECIDER_LIST[1] {
+            "not".to_string()
+        } else if decider == DECIDER_LIST[2] {
+            "preimage_exists".to_string()
+        } else if decider == DECIDER_LIST[3] {
+            "for_all_such_that".to_string()
+        } else if decider == DECIDER_LIST[4] {
+            "or".to_string()
+        } else if decider == DECIDER_LIST[5] {
+            "signed_by".to_string()
+        } else if decider == DECIDER_LIST[6] {
+            "has_lower_nonce".to_string()
+        } else if decider == DECIDER_LIST[7] {
+            "included_at_block".to_string()
+        } else if decider == DECIDER_LIST[8] {
+            "is_deprecated".to_string()
+        } else if decider == DECIDER_LIST[9] {
+            "ownership".to_string()
+        } else if decider == DECIDER_LIST[10] {
+            "there_exists_such_that".to_string()
+        } else if decider == DECIDER_LIST[11] {
+            "verify_tx".to_string()
+        } else if decider == DECIDER_LIST[20] {
+            "q_range".to_string()
+        } else if decider == DECIDER_LIST[21] {
+            "q_less_than".to_string()
+        } else if decider == DECIDER_LIST[22] {
+            "q_block".to_string()
+        } else if decider == DECIDER_LIST[23] {
+            "q_signed_by".to_string()
+        } else if decider == DECIDER_LIST[24] {
+            "q_hash".to_string()
+        } else if decider == DECIDER_LIST[25] {
+            "q_tx".to_string()
+        } else if decider == DECIDER_LIST[26] {
+            "q_property".to_string()
+        } else if decider == DECIDER_LIST[27] {
+            "q_state_update".to_string()
+        } else {
+            "undefined".to_string()
+        }
     }
 }
 
@@ -230,7 +284,8 @@ mod tests {
     use crate::types::PropertyInput;
     use crate::DeciderManager;
     use abi_utils::{Decodable, Encodable};
-    use ethereum_types::H256;
+    use bytes::Bytes;
+    use ethereum_types::{Address, H256};
 
     #[test]
     fn test_encode_and_decode_property() {
@@ -241,5 +296,34 @@ mod tests {
         let encoded = property.to_abi();
         let decoded = Property::from_abi(&encoded).unwrap();
         assert_eq!(decoded, property);
+    }
+
+    #[test]
+    fn test_property_type_string() {
+        let property = DeciderManager::signed_by_decider(vec![
+            PropertyInput::ConstantAddress(Address::zero()),
+            PropertyInput::ConstantBytes(Bytes::default()),
+        ]);
+
+        assert_eq!(property.get_type_string(), "signed_by(address,bytes)");
+    }
+
+    #[test]
+    fn test_nested_property_type_string() {
+        // ownership property
+        let property = DeciderManager::there_exists_such_that(vec![
+            PropertyInput::ConstantProperty(DeciderManager::q_tx(vec![
+                PropertyInput::Placeholder(Bytes::from("state_update")),
+            ])),
+            PropertyInput::ConstantBytes(Bytes::from("tx")),
+            PropertyInput::ConstantProperty(DeciderManager::signed_by_decider(vec![
+                PropertyInput::ConstantAddress(Address::zero()),
+                PropertyInput::Placeholder(Bytes::from("tx")),
+            ])),
+        ]);
+        assert_eq!(
+            property.get_type_string(),
+            "there_exists_such_that(q_tx(placeholder),bytes,signed_by(address,placeholder))"
+        );
     }
 }

--- a/ovm/src/types/property_input.rs
+++ b/ovm/src/types/property_input.rs
@@ -38,6 +38,19 @@ impl PropertyInput {
             panic!("PropertyInput isn't StateUpdate!")
         }
     }
+    pub fn get_type_string(&self) -> String {
+        match self {
+            PropertyInput::Placeholder(_) => "placeholder".to_string(),
+            PropertyInput::ConstantAddress(_) => "address".to_string(),
+            PropertyInput::ConstantBytes(_) => "bytes".to_string(),
+            PropertyInput::ConstantH256(_) => "h256".to_string(),
+            PropertyInput::ConstantInteger(_) => "integer".to_string(),
+            PropertyInput::ConstantRange(_) => "range".to_string(),
+            PropertyInput::ConstantProperty(property) => property.get_type_string(),
+            PropertyInput::ConstantStateUpdate(_) => "state_update".to_string(),
+            PropertyInput::ConstantMessage(_) => "message".to_string(),
+        }
+    }
 }
 
 impl Encodable for PropertyInput {

--- a/ovm/src/types/state_update.rs
+++ b/ovm/src/types/state_update.rs
@@ -1,5 +1,8 @@
 use crate::property_executor::PropertyExecutor;
-use crate::types::core::{Property, QuantifierResultItem};
+use crate::types::{
+    core::{Property, QuantifierResultItem},
+    PropertyInput,
+};
 use crate::DecideMixin;
 use abi_derive::{AbiDecodable, AbiEncodable};
 use abi_utils::{Decodable, Encodable, Integer};
@@ -68,6 +71,19 @@ impl StateUpdate {
     pub fn get_amount(&self) -> u64 {
         self.range.get_end() - self.range.get_start()
     }
+
+    // pub fn get_owner(&self) -> Address {
+    //     let property = self.property;
+    //     // if property is ownership
+    //     if property.inputs.len() == 3 {
+    //         match property.inputs[2] {
+    //             PropertyInput::ConstantProperty(property) => {
+
+    //             }
+    //         }
+    //     }
+    //     // TODO: handle other property.
+    // }
 
     pub fn verify_state_transition<T: KeyValueStore>(
         &self,

--- a/ovm/src/types/state_update.rs
+++ b/ovm/src/types/state_update.rs
@@ -72,6 +72,14 @@ impl StateUpdate {
         self.range.get_end() - self.range.get_start()
     }
 
+    pub fn set_start(&mut self, start: u64) {
+        self.range = Range::new(start, self.get_range().get_end());
+    }
+
+    pub fn set_end(&mut self, end: u64) {
+        self.range = Range::new(self.get_range().get_start(), end);
+    }
+
     pub fn is_ownership_state(&self) -> bool {
         self.property.get_type_string()
             == "there_exists_such_that(q_tx(placeholder),bytes,signed_by(address,placeholder))"

--- a/ovm/src/types/state_update.rs
+++ b/ovm/src/types/state_update.rs
@@ -72,18 +72,25 @@ impl StateUpdate {
         self.range.get_end() - self.range.get_start()
     }
 
-    // pub fn get_owner(&self) -> Address {
-    //     let property = self.property;
-    //     // if property is ownership
-    //     if property.inputs.len() == 3 {
-    //         match property.inputs[2] {
-    //             PropertyInput::ConstantProperty(property) => {
+    pub fn is_ownership_state(&self) -> bool {
+        self.property.get_type_string()
+            == "there_exists_such_that(q_tx(placeholder),bytes,signed_by(address,placeholder))"
+    }
 
-    //             }
-    //         }
-    //     }
-    //     // TODO: handle other property.
-    // }
+    pub fn get_owner(&self) -> Address {
+        // if property is ownership
+        if self.is_ownership_state() {
+            return match &self.property.inputs[2] {
+                PropertyInput::ConstantProperty(property) => match property.inputs[0] {
+                    PropertyInput::ConstantAddress(addr) => addr,
+                    _ => panic!("not ownership property."),
+                },
+                _ => panic!("this is not ownership property."),
+            };
+        }
+        panic!("Not ownership property.");
+        // TODO: handle other property.
+    }
 
     pub fn verify_state_transition<T: KeyValueStore>(
         &self,


### PR DESCRIPTION
I added a couple of changes in this PR.

## Add property_type in string
I added a concept of property_type to distinctively tell property's type. Using eth ABIish type string. 
For example, state_update's property would be
`"there_exists_such_that(q_tx(placeholder),bytes,signed_by(address,placeholder))"`
This is needed because we need to tell a property is ownership property.

one thing I want to discuss is `placeholder`. In this change, I put placeholder as `placeholder` but maybe `placeholder` is better to be replaced as a concrete type.

## Add RangeDb Update, fix stateDb put_verified_state_update
I added `update` to rangestore along with range_db.